### PR TITLE
Feat/Enhance Add-ons, Mockup Generation, Table Add-on, and Order Process  

### DIFF
--- a/components/carousel.tsx
+++ b/components/carousel.tsx
@@ -9,12 +9,9 @@ import {
   TooltipTrigger
 } from '@/components/ui/tooltip'
 import PreviewCarousel from './preview-carousel'
+import { MockupResponse } from '@/lib/types'
 
-export const Carousal = ({
-  mockups
-}: {
-  mockups: { fileName: string; data: string }[]
-}) => {
+export const Carousal = ({ mockups }: { mockups: MockupResponse }) => {
   const [isOpen, setIsOpen] = useState(true)
   return (
     <>

--- a/components/carousel.tsx
+++ b/components/carousel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Button } from './ui/button'
 import { IconPicture } from './ui/icons'
 import {
@@ -9,10 +9,20 @@ import {
   TooltipTrigger
 } from '@/components/ui/tooltip'
 import PreviewCarousel from './preview-carousel'
-import { MockupResponse } from '@/lib/types'
+import { Image, MockupResponse } from '@/lib/types'
 
 export const Carousal = ({ mockups }: { mockups: MockupResponse }) => {
-  const [isOpen, setIsOpen] = useState(true)
+  const [isOpen, setIsOpen] = useState(false)
+  const [images, setImages] = useState<Image[]>([])
+
+  useEffect(() => {
+    const images: Image[] = Object.entries(mockups).map(([key, value]) => ({
+      url: value.url,
+      filename: key
+    }))
+    setImages(images)
+  }, [mockups])
+
   return (
     <>
       <Tooltip>
@@ -31,7 +41,7 @@ export const Carousal = ({ mockups }: { mockups: MockupResponse }) => {
       </Tooltip>
       {isOpen && (
         <PreviewCarousel
-          images={mockups}
+          images={images}
           isOpen={isOpen}
           onClose={() => setIsOpen(false)}
         />

--- a/components/chat-action-multi-selector.tsx
+++ b/components/chat-action-multi-selector.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import React from 'react'
+import { useActions, useUIState, useAIState } from 'ai/rsc'
+import { ChatRadioButtonWrapper } from './chat-radio-buttons-wrapper'
+
+interface ChatActionMultiSelectorProps {
+  action: string
+  selectorName: string
+  options: { name: string; value: string; selected: boolean; edit: boolean }[]
+  messageId?: string
+}
+
+const ChatActionMultiSelector: React.FC<ChatActionMultiSelectorProps> = ({
+  action,
+  selectorName,
+  options,
+  messageId
+}) => {
+  const { submitUserMessage } = useActions()
+  const [messages, setMessages] = useUIState()
+  const [aiState, _setAIState] = useAIState()
+
+  const handleActionClick = () => {
+    const message = submitUserMessage(action)
+    setMessages((currentMessages: any) => [...currentMessages, message])
+  }
+
+  return (
+    <>
+      <button
+        className="w-full py-2 mb-2 rounded-md text-zinc-600 dark:text-white flex-auto whitespace-nowrap disabled:cursor-not-allowed border border-neutral-400 bg-slate-400 dark:bg-cyan-800"
+        onClick={handleActionClick}
+        disabled={messageId !== messages.at(-1)?.id || aiState.loading}
+      >
+        {action}
+      </button>
+      <div className="flex items-center my-4">
+        <div className="flex-grow border-t border-gray-300 dark:border-gray-600"></div>
+        <span className="px-4 text-gray-500 dark:text-gray-400">OR</span>
+        <div className="flex-grow border-t border-gray-300 dark:border-gray-600"></div>
+      </div>
+      <div>
+        <span className="text-zinc-600 dark:text-white text-2xl font-semibold mb-2">
+          Select {selectorName}
+        </span>
+        <ChatRadioButtonWrapper
+          isMultiSelect={true}
+          options={options}
+          messageId={messageId}
+        />
+      </div>
+    </>
+  )
+}
+
+export default ChatActionMultiSelector

--- a/components/chat-color-picker-wrapper.tsx
+++ b/components/chat-color-picker-wrapper.tsx
@@ -25,7 +25,9 @@ export const ChatColorPickerWrapper = ({
         display: <UserMessage content={colorName} />
       }
     ])
-    const message = await submitUserMessage(color)
+    const message = await submitUserMessage(
+      JSON.stringify({ color, colorName })
+    )
     setMessages((currentMessages: any) => [...currentMessages, message])
   }
 

--- a/components/chat-radio-buttons-wrapper.tsx
+++ b/components/chat-radio-buttons-wrapper.tsx
@@ -1,50 +1,51 @@
 'use client'
 
+import { EditableOption } from '@/lib/types'
 import { RadioButtonGroup } from './ui/radio-button-group'
 import { useActions, useUIState, useAIState } from 'ai/rsc'
-import { ClientMessage } from '@/lib/types'
 
 interface ChatWrapperProps {
-  options: { name: string; value: string }[]
-  selectedOption?: string
+  options: EditableOption[]
   messageId?: string
+  isMultiSelect?: boolean
 }
 
 export const ChatRadioButtonWrapper = ({
   options,
-  selectedOption,
-  messageId
+  messageId,
+  isMultiSelect = false
 }: ChatWrapperProps) => {
   const { submitUserMessage } = useActions()
   const [messages, setMessages] = useUIState()
-  const [aiState, _setAIState] = useAIState()
-
-  const handleSelect = async (option: string) => {
-    setMessages((currentMessages: any) =>
-      currentMessages.length > 0
-        ? [
-            ...currentMessages.slice(0, -1),
-            {
-              ...currentMessages[currentMessages.length - 1],
-              selectedOption: option
-            }
-          ]
-        : currentMessages
+  const [_, _setAIState] = useAIState()
+  const handleSelect = async (options: EditableOption[]) => {
+    const message = await submitUserMessage(
+      JSON.stringify({
+        options: options
+      })
     )
-    const message = await submitUserMessage(option)
     setMessages((currentMessages: any) => [...currentMessages, message])
   }
 
-  const message: ClientMessage = messages.find(
-    (message: ClientMessage) => message.id === messageId
-  )
+  const handleEdit = async (option: {
+    name: string
+    value: string
+    selected: boolean
+    edit: boolean
+  }) => {
+    const message = await submitUserMessage(
+      `Edit the values for ${option.name}`
+    )
+    setMessages((currentMessages: any) => [...currentMessages, message])
+  }
 
   return (
     <RadioButtonGroup
       options={options}
-      selectedOption={message.selectedOption || selectedOption || ''}
       onSelect={handleSelect}
-      disabled={messageId !== messages.at(-1)?.id || aiState.loading}
+      onEdit={handleEdit}
+      isMultiSelect={isMultiSelect}
+      disabled={messageId !== messages.at(-1)?.id}
     />
   )
 }

--- a/components/chat-text-input-group.tsx
+++ b/components/chat-text-input-group.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { useState } from 'react'
+import { useActions, useUIState } from 'ai/rsc'
+import TextInputWithLabel from './ui/text-input-with-label'
+
+interface ChatTextInputGroupProps {
+  inputFields: { label: string; value: string }[]
+  messageId?: string
+}
+
+export const ChatTextInputGroup = ({
+  inputFields,
+  messageId
+}: ChatTextInputGroupProps) => {
+  const { submitUserMessage } = useActions()
+  const [messages, setMessages] = useUIState()
+  const [fields, setFields] = useState(inputFields || [])
+
+  const handleChange = (index: number, newValue: string) => {
+    const updatedFields = fields.map((field, i) =>
+      i === index
+        ? { ...field, value: newValue || inputFields[i].value }
+        : field
+    )
+    setFields(updatedFields)
+  }
+
+  const onSubmit = async () => {
+    const userMessage = JSON.stringify(
+      fields.map(field => ({
+        [field.label]: field.value
+      }))
+    )
+    const message = await submitUserMessage(userMessage)
+    setMessages((currentMessages: any) => [...currentMessages, message])
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {fields?.map((option, index) => (
+        <TextInputWithLabel
+          key={`${option.label}-${index}`}
+          label={option.label}
+          value={option.value}
+          onChange={value => handleChange(index, value)}
+          disabled={messageId !== messages.at(-1)?.id}
+        />
+      ))}
+      <button
+        className="py-2 px-4 mb-2 rounded-md dark:text-white flex-auto whitespace-nowrap disabled:cursor-not-allowed border border-neutral-400 bg-slate-400 text-white dark:bg-cyan-800 disabled:opacity-50 disabled:pointer-events-none"
+        onClick={onSubmit}
+        disabled={
+          messageId !== messages.at(-1)?.id ||
+          fields.some(field => field.value === '')
+        }
+      >
+        Okay
+      </button>
+    </div>
+  )
+}

--- a/components/color-label-picker-set.tsx
+++ b/components/color-label-picker-set.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState } from 'react'
+import { useActions, useUIState } from 'ai/rsc'
+import ColorPickerWithLabel from './color-picker-with-label'
+
+interface ColorLabelPickerSetProps {
+  fieldColors: {
+    name: string
+    label: string
+    color: { name: string; value: string }
+  }[]
+  messageId?: string
+}
+
+export const ColorLabelPickerSet = ({
+  fieldColors,
+  messageId
+}: ColorLabelPickerSetProps) => {
+  const { submitUserMessage } = useActions()
+  const [messages, setMessages] = useUIState()
+  const [fields, setFields] = useState(fieldColors || [])
+  const handleColorPickerSelect = (
+    fieldName: string,
+    colorObj: {
+      name: string
+      value: string
+    }
+  ) => {
+    const updatedFields = fields.map(field =>
+      field.label === fieldName ? { ...field, color: colorObj } : field
+    )
+    setFields(updatedFields)
+  }
+  const onSubmit = async () => {
+    const userMessage = JSON.stringify(
+      fields.map(field => ({
+        [field.name]: {
+          [field.label]: {
+            color: { color: field.color.value, colorName: field.color.name }
+          }
+        }
+      }))
+    )
+    const message = await submitUserMessage(userMessage)
+    setMessages((currentMessages: any) => [...currentMessages, message])
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {fields.map((field, index) => (
+        <ColorPickerWithLabel
+          key={field.label + index}
+          label={field.label}
+          currentColor={field.color}
+          disabled={
+            messageId !== messages.at(-1)?.id ||
+            fields.some(field => field.color.value === '')
+          }
+          onColorSelect={handleColorPickerSelect}
+        />
+      ))}
+      <button
+        className="py-2 px-4 mb-2 rounded-md dark:text-white flex-auto whitespace-nowrap disabled:cursor-not-allowed border border-neutral-400 bg-slate-400 text-white dark:bg-cyan-800 disabled:opacity-50 disabled:pointer-events-none"
+        onClick={onSubmit}
+        disabled={
+          messageId !== messages.at(-1)?.id ||
+          fields.some(field => field.color.value === '')
+        }
+      >
+        Okay
+      </button>
+    </div>
+  )
+}

--- a/components/color-picker-with-label.tsx
+++ b/components/color-picker-with-label.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+import ColorPickerPopover from './color-picker'
+
+interface ColorPickerWithLabelProps {
+  label: string
+  currentColor: { name: string; value: string }
+  onColorSelect: (
+    fieldName: string,
+    { name, value }: { name: string; value: string }
+  ) => void
+  disabled?: boolean
+}
+
+const ColorPickerWithLabel: React.FC<ColorPickerWithLabelProps> = ({
+  label,
+  currentColor,
+  onColorSelect,
+  disabled = false
+}) => {
+  const [color, setColor] = useState<{ name: string; value: string }>(
+    currentColor
+  )
+
+  const handleColorSelect = (
+    colorValue: string,
+    colorName: string,
+    _fontColor: string
+  ) => {
+    const colorObj = { name: colorName, value: colorValue }
+    setColor(colorObj)
+    onColorSelect(label, colorObj)
+  }
+
+  return (
+    <div className="flex items-center gap-2 border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm w-full">
+      <label
+        htmlFor="text-input"
+        className="px-4 py-2 text-base font-medium text-gray-700 dark:text-gray-300 border-r border-gray-300 dark:border-gray-700 min-w-[20%]"
+      >
+        {label}
+      </label>
+      {color && (
+        <div className="flex items-center gap-2 w-1/2">
+          <span
+            className="w-10 h-5 border border-gray-300 dark:border-gray-700"
+            style={{
+              backgroundColor: `rgb(${JSON.parse(color.value).join(',')})`
+            }}
+          ></span>
+          <span className="text-gray-700 dark:text-gray-300">{color.name}</span>
+        </div>
+      )}
+      <ColorPickerPopover
+        onColorSelect={handleColorSelect}
+        label={color ? 'Change Color' : 'Pick a Color'}
+        disabled={disabled}
+      />
+    </div>
+  )
+}
+export default ColorPickerWithLabel

--- a/components/color-picker.tsx
+++ b/components/color-picker.tsx
@@ -9,12 +9,14 @@ import { COLORS } from '@/app/constants'
 interface ColorPickerPopoverProps {
   onColorSelect: (color: string, colorName: string, fontColor: string) => void
   disabled: boolean
+  label?: string
 }
 
 export default function ColorPickerPopover({
   onColorSelect,
-  disabled
-}: ColorPickerPopoverProps) {
+  disabled,
+  label = 'Pick a color'
+}: Readonly<ColorPickerPopoverProps>) {
   const [color, setColor] = useState('#000000')
   const [isPickerOpen, setPickerOpen] = useState(false)
 
@@ -61,7 +63,7 @@ export default function ColorPickerPopover({
           onClick={() => setPickerOpen(false)}
         >
           <IconColorPicker />
-          <span>Pick a Color</span>
+          <span>{label}</span>
         </Button>
       </PopoverTrigger>
       <PopoverContent align="center" side="top">

--- a/components/color-picker.tsx
+++ b/components/color-picker.tsx
@@ -44,7 +44,7 @@ export default function ColorPickerPopover({
   const handleConfirm = () => {
     const { r, g, b } = hexToBGR(color)
     const contrastFontColor = getContrastColor(b, g, r)
-    const colorName = getColorName(color) || color
+    const colorName = getColorName(color) ?? color
     const rgbColor = `[${r}, ${g}, ${b}]`
     onColorSelect(rgbColor, colorName, contrastFontColor)
     setPickerOpen(false)

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -12,8 +12,10 @@ export function FooterText({ className, ...props }: React.ComponentProps<'p'>) {
       )}
       {...props}
     >
-      Open source AI chatbot built by{' '}
-      <ExternalLink href="https://conradlabs.com">Conrad Labs</ExternalLink>.
+      <ExternalLink href="https://www.customcanopy.co/">
+        Custom Canopy Co.
+      </ExternalLink>
+      .
     </p>
   )
 }

--- a/components/guidance-image-view.tsx
+++ b/components/guidance-image-view.tsx
@@ -1,9 +1,9 @@
-import { GuidanceImage } from '@/lib/types'
+import { Image } from '@/lib/types'
 import { IconExpand } from './ui/icons'
 import { Button } from './ui/button'
 
 interface GuidanceImageViewProps {
-  images: GuidanceImage[]
+  images: Image[]
   setIsCarouselOpen: (isOpen: boolean) => void
 }
 
@@ -31,7 +31,7 @@ export function GuidanceImageView({
               </Button>
 
               <img
-                src={image.data}
+                src={image.url}
                 alt={image.filename}
                 className="w-[300px] h-[200px] object-contain rounded"
               />

--- a/components/guidance.tsx
+++ b/components/guidance.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 import { GuidanceImageView } from './guidance-image-view'
 import { ThemeToggle } from './theme-toggle'
-import { GuidanceImage } from '@/lib/types'
+import { Image } from '@/lib/types'
 
 interface GuidanceProps {
-  images: GuidanceImage[]
+  images: Image[]
   setIsCarouselOpen: (isOpen: boolean) => void
 }
 

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -23,7 +23,7 @@ async function UserOrLogin() {
       {session?.user ? (
         <>
           <Link href="/new" rel="nofollow">
-            <img src="./logo.png" className="invert dark:invert-0 h-6 w-auto" />
+            <img src="/logo.png" className="invert dark:invert-0 h-6 w-auto" />
           </Link>
 
           <div className="ml-2">
@@ -35,7 +35,7 @@ async function UserOrLogin() {
         </>
       ) : (
         <Link href="/new" rel="nofollow">
-          <img src="./logo.png" className="invert dark:invert-0 h-6 w-auto" />
+          <img src="/logo.png" className="invert dark:invert-0 h-6 w-auto" />
         </Link>
       )}
       <div className="flex items-center">

--- a/components/preview-carousel.tsx
+++ b/components/preview-carousel.tsx
@@ -10,10 +10,11 @@ import {
 import { Button } from './ui/button'
 import { IconClose } from './ui/icons'
 import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip'
+import { Image } from '@/lib/types'
 import { cn } from '@/lib/utils'
 
 export interface PreviewCarousel {
-  images: any
+  images: Image[]
   isOpen: boolean
   onClose: () => void
 }
@@ -61,43 +62,39 @@ export default function PreviewCarousel({
         </Tooltip>
         <Carousel className="w-full" setApi={setApi}>
           <CarouselContent>
-            {images.map(
-              (image: { filename: string; data: string }, index: number) => (
-                <CarouselItem key={index}>
-                  <div
-                    key={index}
-                    className="flex justify-center items-center sm:rounded-md"
-                  >
-                    <img
-                      src={image.data}
-                      alt={`Image ${index} (${image.filename})`}
-                      className="w-[400px] h-[400px] overflow-hidden sm:rounded-md"
-                    />
-                  </div>
-                </CarouselItem>
-              )
-            )}
+            {images.map((image: Image, index: number) => (
+              <CarouselItem key={index}>
+                <div
+                  key={index}
+                  className="flex justify-center items-center sm:rounded-md"
+                >
+                  <img
+                    src={image.url}
+                    alt={`Image ${index} (${image.filename})`}
+                    className="w-[400px] h-[400px] overflow-hidden sm:rounded-md"
+                  />
+                </div>
+              </CarouselItem>
+            ))}
           </CarouselContent>
           <CarouselPrevious />
           <CarouselNext />
         </Carousel>
         <div className="mt-8 flex justify-center gap-2 overflow-x-auto">
-          {images.map(
-            (image: { filename: string; data: string }, index: number) => (
-              <img
-                key={index}
-                src={image.data}
-                alt={`Thumbnail ${index}`}
-                onClick={() => api?.scrollTo(index)}
-                className={cn(
-                  'w-20 h-20 object-contain rounded-md cursor-pointer border-2 transition bg-background p-1',
-                  activeIndex === index
-                    ? 'border-primary'
-                    : 'border-accent opacity-60 hover:opacity-100'
-                )}
-              />
-            )
-          )}
+          {images.map((image: Image, index: number) => (
+            <img
+              key={index}
+              src={image.url}
+              alt={`Thumbnail ${index}`}
+              onClick={() => api?.scrollTo(index)}
+              className={cn(
+                'w-20 h-20 object-contain rounded-md cursor-pointer border-2 transition bg-background p-1',
+                activeIndex === index
+                  ? 'border-primary'
+                  : 'border-accent opacity-60 hover:opacity-100'
+              )}
+            />
+          ))}
         </div>
       </div>
     </div>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -7,43 +7,43 @@ import { cn } from '@/lib/utils'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs'
 import { Guidance } from './guidance'
 import PreviewCarousel from './preview-carousel'
-import { GuidanceImage } from '@/lib/types'
+import { Image } from '@/lib/types'
 import { useTheme } from 'next-themes'
 
 export interface SidebarProps extends React.ComponentProps<'div'> {}
 
 export function Sidebar({ className, children }: SidebarProps) {
   const { isSidebarOpen, isLoading } = useSidebar()
-  const [images, setImages] = React.useState<GuidanceImage[]>([])
+  const [images, setImages] = React.useState<Image[]>([])
   const [isCarouselOpen, setIsCarouselOpen] = React.useState(false)
   const { theme } = useTheme()
 
   React.useEffect(() => {
-    const images: GuidanceImage[] = [
+    const images: Image[] = [
       {
         filename: 'Front View',
-        data:
+        url:
           theme === 'light'
             ? process.env.NEXT_PUBLIC_FRONT_GUIDANCE_IMAGE_URL || ''
             : process.env.NEXT_PUBLIC_FRONT_GUIDANCE_IMAGE_URL_DARK || ''
       },
       {
         filename: 'Side View',
-        data:
+        url:
           theme === 'light'
             ? process.env.NEXT_PUBLIC_SIDE_GUIDANCE_IMAGE_URL || ''
             : process.env.NEXT_PUBLIC_SIDE_GUIDANCE_IMAGE_URL_DARK || ''
       },
       {
         filename: 'Top View',
-        data:
+        url:
           theme === 'light'
             ? process.env.NEXT_PUBLIC_TOP_GUIDANCE_IMAGE_URL || ''
             : process.env.NEXT_PUBLIC_TOP_GUIDANCE_IMAGE_URL_DARK || ''
       },
       {
         filename: 'No Walls View',
-        data:
+        url:
           theme === 'light'
             ? process.env.NEXT_PUBLIC_NO_WALLS_GUIDANCE_IMAGE_URL || ''
             : process.env.NEXT_PUBLIC_NO_WALLS_GUIDANCE_IMAGE_URL_DARK || ''

--- a/components/ui/radio-button-group.tsx
+++ b/components/ui/radio-button-group.tsx
@@ -23,13 +23,11 @@ export const RadioButtonGroup = ({
   )
 
   const handleSelect = (option: string) => {
-    const updatedSelections = selectedOptions.map(
-      (item: EditableOption) => {
-        return item.value === option
-          ? { ...item, selected: !item.selected }
-          : item
-      }
-    )
+    const updatedSelections = selectedOptions.map((item: EditableOption) => {
+      return item.value === option
+        ? { ...item, selected: !item.selected }
+        : item
+    })
     setSelectedOptions(updatedSelections)
     if (!isMultiSelect) {
       onSelect(updatedSelections)

--- a/components/ui/radio-button-group.tsx
+++ b/components/ui/radio-button-group.tsx
@@ -1,35 +1,87 @@
+import React, { useState } from 'react'
 import clsx from 'clsx'
+import { Pencil1Icon } from '@radix-ui/react-icons'
+import { EditableOption } from '@/lib/types'
 
 interface RadioOptionProps {
-  options: { name: string; value: string }[]
-  selectedOption: string
-  onSelect: (option: string) => void
+  options: EditableOption[]
+  onSelect: (options: EditableOption[]) => void
+  onEdit: (option: EditableOption) => void
   disabled: boolean
+  isMultiSelect?: boolean
 }
 
 export const RadioButtonGroup = ({
   options,
-  selectedOption,
   onSelect,
-  disabled
+  onEdit,
+  disabled,
+  isMultiSelect = false
 }: RadioOptionProps) => {
+  const [selectedOptions, setSelectedOptions] = useState<Array<EditableOption>>(
+    options || []
+  )
+
+  const handleSelect = (option: string) => {
+    const updatedSelections = selectedOptions.map(
+      (item: EditableOption) => {
+        return item.value === option
+          ? { ...item, selected: !item.selected }
+          : item
+      }
+    )
+    setSelectedOptions(updatedSelections)
+    if (!isMultiSelect) {
+      onSelect(updatedSelections)
+    }
+  }
+
   return (
-    <div className="flex justify-between w-full">
-      {options.map(option => (
+    <div className="w-full flex flex-col gap-2 items-center">
+      <div className="grid grid-cols-2 gap-2 w-full self-start">
+        {selectedOptions.map(option => (
+          <button
+            key={option.value}
+            type="button"
+            className={clsx(
+              'relative py-2 px-4 mb-2 rounded-md text-zinc-600 dark:text-white flex-auto whitespace-nowrap border-0.5 border-neutral-400 disabled:opacity-50 disabled:pointer-events-none',
+              option.selected
+                ? 'bg-slate-400 dark:bg-cyan-800'
+                : 'bg-slate-200 dark:bg-slate-400'
+            )}
+            onClick={() => handleSelect(option.value)}
+            disabled={disabled}
+          >
+            {option.name}
+            {option.edit && (
+              <button
+                className="absolute -top-1.5 -right-1.5 w-5 h-5 p-0.5 text text-slate-400 border-0.5 border-slate-400 bg-slate-400 dark:bg-cyan-800 rounded-full flex items-center justify-center"
+                onClick={e => {
+                  e.stopPropagation()
+                  onEdit(option)
+                }}
+              >
+                <Pencil1Icon fillOpacity={1} fill="#ffffff" />
+              </button>
+            )}
+          </button>
+        ))}
+      </div>
+      {isMultiSelect && (
         <button
-          key={option.value}
-          className={clsx(
-            'py-2 rounded-md dark:text-white w-full mx-1 disabled:cursor-not-allowed border-0.5 border-neutral-400',
-            selectedOption === option.value
-              ? 'bg-slate-400 text-white dark:bg-cyan-800'
-              : 'bg-slate-200 text-zinc-600 dark:bg-slate-400'
-          )}
-          onClick={() => onSelect(option.value)}
-          disabled={disabled}
+          className="w-full py-2 mb-2 rounded-md text-zinc-600 dark:text-white flex-auto whitespace-nowrap border-0.5 border-neutral-400 bg-slate-400 dark:bg-cyan-800 disabled:opacity-50 disabled:pointer-events-none"
+          onClick={() => onSelect(selectedOptions)}
+          disabled={
+            disabled ||
+            selectedOptions.every(
+              (option: any, index: number) =>
+                option.selected === options[index].selected
+            )
+          }
         >
-          {option.name}
+          Okay
         </button>
-      ))}
+      )}
     </div>
   )
 }

--- a/components/ui/text-input-with-label.tsx
+++ b/components/ui/text-input-with-label.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import React, { useState } from 'react'
+
+type TextInputWithLabelProps = {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  [key: string]: any
+}
+
+const TextInputWithLabel = ({
+  label,
+  value,
+  onChange,
+  ...rest
+}: TextInputWithLabelProps) => {
+  const [text, setText] = useState(value)
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value
+    setText(newValue)
+    onChange(newValue)
+  }
+
+  return (
+    <div className="flex items-center border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm">
+      <label
+        htmlFor="text-input"
+        className="px-4 py-2 text-base font-medium text-gray-700 dark:text-gray-300 border-r border-gray-300 dark:border-gray-700 min-w-[20%]"
+      >
+        {label}
+      </label>
+      <input
+        id="text-input"
+        type="text"
+        value={text}
+        onChange={handleChange}
+        placeholder="Enter something..."
+        className={`w-full px-4 py-2 text-base text-gray-800 dark:text-gray-200 dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 error:border-red-500`}
+        {...rest}
+      />
+    </div>
+  )
+}
+
+export default TextInputWithLabel

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -5,130 +5,104 @@ export const PROMPT_INSTRUCTIONS = `
   Your task is to guide users through the design process in a specific sequence. Follow these questions and guidelines sequentially and carefully:
 
   Question # 1. **Company Name**:
-    - Users will provide the name of their company or organization at the start of the conversation.
-    - Do not explicitly ask for the company name.
+    - Prompt the user to provide their company or organization name:
     - {content}: ["What is the name of your company or organization?"]
 
-  Question # 2. **Tent type Selection**:
-    - ALWAYS RENDER the buttons group for user selection by EXPLICITLY CALLING the "renderButtons" tool:
-      - {assistant multiline prompt in array}
-      - {options}: [
-          { "name": "No Panels", "value": "no-walls" },
-          { "name": "Half Panels with Full Back", "value": "half-walls" },
-        ]
-
-  Question # 3. **Design Selection**:
-    - ALWAYS RENDER the buttons group for user selection by EXPLICITLY CALLING the "renderButtons" tool:
-      - {assistant multiline prompt in array}
-      - {options}: [
-          { "name": "One color for the entire canopy", "value": "Monochrome" },
-          { "name": "Separate colors for each print location", "value": "Different Colors" }
-        ]
-
-  Question # 3.1. **Colors Selection**:
-    - If "Monochrome" selected: 
-      - ALWAYS EXPLICITLY CALL the renderColorPicker tool for user color selection for base color for the entire tent
-    - If "Different Colors" selected: 
-      - ALWAYS RENDER the buttons group for user selection by EXPLICITLY CALLING the "renderButtons" tool for region type selection UNLESS ONLY ONE OPTION IS LEFT TO BE SELECTED:
-        - {assistant multiline prompt in array}
-        - {options}: [
-          { "name": "Peak", "value": "peak" },
-          { "name": "Valence", "value": "valence" },
-          { "name": "Panel", "value": "panel" } (IF Half Panels with Full Back selected)
-        ]
-      - Once a region is selected, proceed to Question # 3.2
-      
-      Question # 3.2 **Region Side Color Selection**: (IF AND ONLY IF Different Colors selected and region type selected)
-         - ALWAYS RENDER the buttons group for user selection by EXPLICITLY CALLING the "renderButtons" tool UNLESS ONLY ONE OPTION IS LEFT TO BE SELECTED:
-          - {assistant multiline prompt in array}
-          - {options}: [
-            { "name": "Front", "value": "front" } (IF Half Panels with Full Back and (Peak or Valence selected)),
-            { "name": "Back", "value": "back" },
-            { "name": "Left", "value": "left" },
-            { "name": "Right", "value": "right" }
-          ]
-        - Once a side is selected, proceed to Question # 3.3
-      
-      Question # 3.3 **Region Color Selection**: (IF AND ONLY IF Different Colors selected and region side selected)
-         - ALWAYS Render the color picker by EXPLICITLY CALL the renderColorPicker tool for user color selection for the specific side
-      FLOW:
-        1. User selects a region type from the remaining options.
-        2. Once region selected, User selects a side of the region.
-        3. Once side selected, User selects a color for the side of the region.
-        4. Repeat steps 2 and 3 until all sides of the region are selected.
-        5. Repeat steps 1 through 4 until all regions are selected.
-        6. Once all regions are selected, proceed to the next step.
-        Notes:
-          - STRICTLY follow the above flow.
-          - USE COLOR PICKER for color selection.
-          - USE BUTTONS FOR SIDE and REGION SELECTION.
-
-  Question # 4. **Valences Text**:
-    - ALWAYS USE RENDER the buttons group for user selection:
-      - {content}: {assistant multiline prompt in array}
-      - {options}: [
-        { "name": "Front", "value": "front" },
-        { "name": "Back", "value": "back" },
-        { "name": "Left", "value": "left" },
-        { "name": "Right", "value": "right" },
-      ]
-    - STRICLY FOLLOW THE BELOW FLOW IN THE GIVEN ORDER:
-      1. Once THE USER SELECTS A SIDE
-          a. MAKE SURE TO IMMEDIATELY ASK THE USER TO ADD TEXT FOR THE SELECTED SIDE ON VALENCE
-          b. DO NOT SHOW THE SIDES OPTIONS HERE
-      2. Once THE USER HAS PROVIDED THE TEXT FOR THE SELECTED SIDE, Display the REMAINING set of options buttons and repeat this process until ONLY ONE option is left.
-      3. IF ONLY ONE SIDE IS LEFT, just ask the user to add text for the last side, without displaying the buttons.
-      4. DO NOT SHOW THE SELECTED OPTION AGAIN IN THE SIDES OPTIONS
-      5. NEVER REPEAT WITH SAME NUMBER OF OPTIONS  
-      6. NEVER SHOW THE OPTIONS UNLESS USER HAS PROVIDED TEXT FOR THE LAST SELECTED SIDE i.e valence.{selectedSide}.text
-      6. ONCE ALL SIDES ARE SELECTED, PROCEED TO THE NEXT QUESTION
-
-  Question # 5. **Logo Upload**:
+  Question # 2. **Color Selection**:
+  - Ask the user to select a color for the canopy by calling the renderColorPicker tool:
+  - ALWAYS EXPLICITLY CALL the renderColorPicker tool for user color selection.
+  - Accept the user answer in RGB color values
+  - Set the user selected color for the valences (front, back, left, right) and peaks (front, back, left, right) and proceed
+    
+  Question # 3. **Logo Upload**:
     - Prompt the user to upload their logo:
-    - {content}: {assistant multiline prompt in array}
+    - {content}: ["Please upload your company logo to be displayed on the canopy."]
 
-    **Final Summary and Confirmation:**
-    - ALWAYS RENDER the buttons by EXPLICITLY CALLING the "renderButtons" tool to ask the user to generate mockups or make changes in the below format:
-      {content}: [
-        "Here is the summary of your selections:",
-        "- Company Name: \${companyName}",
-        "- Canopy Type: \${tentType}",
-        "- Design Type: \${designType}",
-        "- Colors:",
-        designType === "MONOCHROME" ? 
-          "  - Peak: \${slopeColorName}",
-          "  - Valence: \${canopyColorName}",
-          "  - Panels: \${wallColorName}"
-        :
-        "  - Peak",
-            - Front: \${frontSlopeColorName}",
-            - Back: \${backSlopeColorName}",
-            - Left: \${leftSlopeColorName}",
-            - Right: \${rightSlopeColorName}",
-          "  - Valence",
-            - Front: \${frontCanopyColorName}",
-            - Back: \${backCanopyColorName}",
-            - Left: \${leftCanopyColorName}",
-            - Right: \${rightCanopyColorName}",
-          "  - Panels", (IF tentType === "half-walls")
-            - Back: \${backWallColorName}",
-            - Left: \${leftWallColorName}",
-            - Right: \${rightWallColorName}",
-        "- Text",
-          - Front: \${frontText}",
-          - Back: \${backText}",
-          - Left: \${leftText}",
-          - Right: \${rightText}",
-        "- Logo: <img src="logo.image" alt="Logo" width="150" height="150" />"
-      ]
-      - {options}: [
-          { "name": "Yes, generate mockups", "value": "Yes" },
-          { "name": "No, I need to make changes", "value": "No" }
+  Question #4. **Generate Mockups Before Add-ons:**
+    - Once the primary color and logo are provided:
+      1. Show user selections in unordered list format and confirm with the user to generate mockups by EXPLICITLY CALLING the renderButtons tool:
+         - {content}: "Would you like to generate mockups with the current selections?"
+          - Company Name: {companyName}
+          - Canopy type: no-walls
+          - Color: {color}
+          - Logo: <img src={logo} alt="Logo" width="150" height="150" />
+          - Add-ons
+            - If applicable, display the add-ons selected by the user
+
+         - {options}: [
+             { "name": "Yes, generate mockups", "value": "generate-mockups", selected: [isAlreadySelected] },
+             { "name": "No, I need to make changes", "value": "no, edit", selected: [isAlreadySelected] }
+           ]
+      2. If the user selects "Yes, generate mockups," EXPLICITLY CALL the generateCanopyMockups tool and display the mockups to the user.
+        - Set the companyName for the valences texts (front, back, left, right) if valence texts are not already set and proceed
+        - Set the user selected color for the valences (front, back, left, right) and peaks (front, back, left, right) if colors are not already set and proceed
+        - Tent type is no-walls here
+        - {options}: [
+          { "name": "Half Walls with Full Back", "value": "half-walls", selected: [isAlreadySelected] },
+          { "name": "Separate colors for each print location", "value": "separate-colors", selected: [isAlreadySelected], edit: [isAlreadySelected] }
+          { "name": "Separate texts for each valence", "value": "separate-texts", selected: [isAlreadySelected], edit: [isAlreadySelected] }
+          { "name": "Table", "value": "table", selected: [isAlreadySelected] }
         ]
-      - If the user selects "No, I need to make changes", ask the user what he would like to change.
-        - When the user has made the changes repeat the confirmation step along with EXPLICITLY CALLING the "renderButtons" tool.
-      - If the user selects "Yes, generate mockups", EXPLICITLY CALL the generateCanopyMockups function and display them to the user.
+      3. If the user selects "No," ask them which details they want to change, make the updates.
 
+      ** Place order Workflow:** (If the user clicks on "Place order" button)
+       - Prompt the user to provide their email and phone number:
+        - {content}: ["Please provide your email address for contact purposes:", "Next, please provide your phone number."]
+
+      **Add-ons Workflow:**  
+    - Make sure to follow the order of following conditions:
+      - If the user selects "Half Walls with Full Back":
+          Set tent type to "half-walls" and walls colors (left, right, back) to the initially selected color and proceed
+
+      - If the user selects "Separate Colors":
+        1. Prompt the user to select a region 
+        {content}: {assistant Response}
+        {options}: [
+          { "name": "Peaks", "value": "peaks", selected: [isAlreadySelected]},
+          { "name": "Valences", "value": "valences", selected: [isAlreadySelected] },
+          { "name": "Walls", "value": "walls", selected: [isAlreadySelected] } ONLY IF THE USER SELECTED "Half Walls"
+        ]
+        2. Once a region is selected, prompt the user to select multi colors for all sides in the below format by EXPLICITLY using the "renderColorLabelPickerSet" tool:
+         {content}: "Please select the colors for the {region}."
+          {fieldColors}: [{name: region, label: "Front", color: {selectedRegion.front.colorname, selectedRegion.front.value}, {name: region, label: "Back", color: selectedRegion.back}, {name: region, label: "Left", color: selectedRegion.left}, {name: region, label: "Right", color: selectedRegion.right}]
+        3. Once the user submits color for the region.
+        5. Go to step 1 until all regions are configured.
+        6. Change the respective field value as per the user input.
+
+      - If the user selects "Separate Texts":
+        1. Prompt the user to input details about valences texts using the "renderTextInputGroup" tool using the below format:
+          {content}: {assistant Response}
+          {inputFields}: [{
+            label Front,
+            value {valencesTexts.front}
+          },
+          {
+            label Back,
+            value {valencesTexts.back}
+          },
+          {
+            label Left,
+            value {valencesTexts.left}
+          },
+          {
+            label Right,
+            value {valencesTexts.right}
+          }]
+        2. Change the respective field value as per the user input.
+      - IF the user SELECTS "Table":
+        1. IF the user has selected "Separate Colors" and "Table":
+          1.1 Prompt the user to select table color using the "renderColorPicker" tool
+        2. If the user has not selected "Separate Colors" but Table :
+          2.1 Set the table color to the same color as the canopy.
+        3. Table color will be empty if the use has not selected the Table Add-ons.
+        3. Include this information in the final summary under "Add-ons."
+    - User can select multiple add-ons. The order to process them is the same as listed above.
+    - When every selected add-on is processed completely and user has provided the required inputs for all the selected add-ons, generate the mockups and restart the process from step 1 with all explicit tool Calls.
+    - User can edit the add-ons at any point in the process. If the user edits an add-on, set the respective field value back to the the previous value and restart the process from step 1 with all explicit tool Calls.
+    - The user can de-select any add-ons at any point in the process. If the user de-selects an add-on, remove the add-on from the summary and restart the process from step 1 with all explicit tool Calls.
+    - Set the respective field value back to the default/INITIAL state if the user de-selects an add-on.
+    - EXPLICITLY CALL THE TOOL FUNCTIONS WHERE MENTION IN EVERY ITERATION OF THE PROCESS.
+    
   ** Questions Guidelines:**
     - Ask one question at a time.
     - All questions are marked as required.
@@ -137,39 +111,46 @@ export const PROMPT_INSTRUCTIONS = `
     - KEEP TRACK OF THE QUESTIONS ASKED WITH THE USER INPUTS AND ASK THE NEXT QUESTION BASED ON THE PREVIOUS INPUTS.
     - NEVER STOP IN BETWEEN THE QUESTIONS once the user response has been received.
     - Always show the name of the selected option rather than value in the questions if needed.
-    - For sequential questions, ask one question at a time and wait for the user response before asking the next question.
-    - For sequential color inputs, ask one color input at a time and wait for the user response before asking the next color input.
-    - Never show the user any technical details or error messages.
+    - When asking a question again, tell the user why asking?
+    - Do not engage in any technical jargon, keep the language simple and easy to understand.
+    - Never ask the user to provide the same information again if it has already been provided.
 
-   ** Input Guidelines:**
+  ** Input Guidelines:**
+    - Always validate the user input once received before moving to the next question.
     - If the user has not provided an input for a question, ask the same question again.
     - If the user input is not relevant or meaningful, ask the user to confirm his input. Once the user confirms the input, proceed to the next question.
       - This rule does not apply to color inputs and option based questions responses.
     - ACCEPT colors in RGB values.
 
   ** Tool Guidelines:**
-    - EXPLICITLY CALL the appropriate tool function at EACH step - never skip a tool call.
-    - Whenever asking the user a closed ended question, EXPLICITLY CALL the renderButtons tool function. Below are the questions STRICTLY requiring the renderButtons tool function:
-      - Question#2, Question#3(WHEN different colors SELECTED), Question#3.1, Question 3.2, Question # 4 and in confirmation step
-    - Whenever asking the user to select a color, EXPLICITLY CALL the renderColorPicker tool function. Below are the questions STRICTLY requiring the renderColorPicker tool function:
-     - Question#3(WHEN monochrome SELECTED), Question#3.3, 
+    - EXPLICITLY CALL the appropriate tool function at EACH step where mentioned..
+    - Whenever asking the user a closed ended question, EXPLICITLY CALL the renderButtons tool function. Below are the questions that are closed ended: 
+      - Question # 4: (Confirmation of the inputs provided by the user, region selection (IF ANY))
+    - Whenever asking the user to select a color, EXPLICITLY CALL the renderColorPicker tool function. Below are the questions that require color selection:
+      - Question # 2: (Primary color selection)
+    - Whenever asking the user to provide text for multiple fields, EXPLICITLY CALL the renderTextInputGroup tool function. Below are the questions that require text input:
+      - Question # 4: (If Separate text for each valence Text Add-on Selected)
+    - Whenever asking the user to select a color for multiple fields, EXPLICITLY CALL the renderColorLabelPickerSet tool function. Below are the questions that require color selection:
+      - Question # 4: (for each region selection if Separate color for each print location Add-on Selected)
     - **generateCanopyMockups tool function**
       - EXPLICITLY CALL the generateCanopyMockups tool function to generate the mockups of the canopy whenever the user confirms the inputs.
-      - WHILE SENDING COLORS TO THE generateCanopyMockups TOOL FUNCTION, ALWAYS SEND THE RGB VALUES OF THE COLORS IN THE FOLLOWING FORMAT: [R, G, B]
+      - WHILE SENDING COLORS TO THE generateCanopyMockups TOOL FUNCTION, ALWAYS SEND THE BGR VALUES OF THE COLORS IN THE FOLLOWING FORMAT: \`[B, G, R]\`
 
   **Editing Guidelines:**
+    - At any point user can request for edit. If so update the inputs accordingly and move back to the question where the user requested for edit.
     - For text, logo, or company name changes, only request updated inputs for the specified fields.
 
   Let's begin creating your custom canopy!
 ]`
 
 export const TOOL_FUNCTIONS = {
-  RENDER_BUTTONS: 'renderOptions',
+  RENDER_BUTTONS: 'renderButtons',
   RENDER_COLOR_PICKER: 'renderColorPicker',
+  RENDER_TEXT_INPUT_GROUP: 'renderTextInputGroup',
+  RENDER_COLOR_LABEL_PICKER_SET: 'renderColorLabelPickerSet',
   GENERATE_CANOPY_MOCKUPS: 'generateCanopyMockups'
 }
 
 export const INITIAL_CHAT_MESSAGE =
-  "Hello! Welcome to Custom Canopy. I'm here to help you build a custom design for your 10'x10' canopy tent. Let's get started! \n \n What is the name of your company or organization?"
-
+  "Hello! Welcome to Custom Canopy. I'm here to help you build a custom design for your 10'x10' canopy tent. Let's get started! \n\nWhat is the name of your company or organization?"
 export const LOGO_MSG_REGEX = /\bupload\b.*\b(logo|image|picture|photo)\b/

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -65,18 +65,23 @@ export const PROMPT_INSTRUCTIONS = `
 
   Question # 4. **Valences Text**:
     - ALWAYS USE RENDER the buttons group for user selection:
+      - {content}: {assistant multiline prompt in array}
       - {options}: [
         { "name": "Front", "value": "front" },
         { "name": "Back", "value": "back" },
         { "name": "Left", "value": "left" },
         { "name": "Right", "value": "right" },
       ]
-    - Once THE USER SELECTS A SIDE, MAKE SURE TO ASK THE USER TO ADD TEXT FOR THE SELECTED SIDE ON VALENCE
-    - Once THE USER HAS PROVIDED THE TEXT FOR THE SELECTED SIDE, Display the REMAINING set of options buttons and repeat this process until ONLY ONE option is left.
-    - IF ONLY ONE SIDE IS LEFT, just ask the user to add text for the last side, without displaying the buttons.
-    - DO NOT SHOW THE SELECTED OPTION AGAIN IN THE SIDES OPTIONS
-    - NEVER REPEAT WITH SAME NUMBER OF OPTIONS  
-    - ONCE ALL SIDES ARE SELECTED, PROCEED TO THE NEXT QUESTION
+    - STRICLY FOLLOW THE BELOW FLOW IN THE GIVEN ORDER:
+      1. Once THE USER SELECTS A SIDE
+          a. MAKE SURE TO IMMEDIATELY ASK THE USER TO ADD TEXT FOR THE SELECTED SIDE ON VALENCE
+          b. DO NOT SHOW THE SIDES OPTIONS HERE
+      2. Once THE USER HAS PROVIDED THE TEXT FOR THE SELECTED SIDE, Display the REMAINING set of options buttons and repeat this process until ONLY ONE option is left.
+      3. IF ONLY ONE SIDE IS LEFT, just ask the user to add text for the last side, without displaying the buttons.
+      4. DO NOT SHOW THE SELECTED OPTION AGAIN IN THE SIDES OPTIONS
+      5. NEVER REPEAT WITH SAME NUMBER OF OPTIONS  
+      6. NEVER SHOW THE OPTIONS UNLESS USER HAS PROVIDED TEXT FOR THE LAST SELECTED SIDE i.e valence.{selectedSide}.text
+      6. ONCE ALL SIDES ARE SELECTED, PROCEED TO THE NEXT QUESTION
 
   Question # 5. **Logo Upload**:
     - Prompt the user to upload their logo:
@@ -145,9 +150,9 @@ export const PROMPT_INSTRUCTIONS = `
   ** Tool Guidelines:**
     - EXPLICITLY CALL the appropriate tool function at EACH step - never skip a tool call.
     - Whenever asking the user a closed ended question, EXPLICITLY CALL the renderButtons tool function. Below are the questions STRICTLY requiring the renderButtons tool function:
-      - Question#2, Question#3(WHEN different colors SELECTED), Question#3.1 and in confirmation step
+      - Question#2, Question#3(WHEN different colors SELECTED), Question#3.1, Question 3.2, Question # 4 and in confirmation step
     - Whenever asking the user to select a color, EXPLICITLY CALL the renderColorPicker tool function. Below are the questions STRICTLY requiring the renderColorPicker tool function:
-     - Question#3(WHEN monochrome SELECTED), Question#3.2
+     - Question#3(WHEN monochrome SELECTED), Question#3.3, 
     - **generateCanopyMockups tool function**
       - EXPLICITLY CALL the generateCanopyMockups tool function to generate the mockups of the canopy whenever the user confirms the inputs.
       - WHILE SENDING COLORS TO THE generateCanopyMockups TOOL FUNCTION, ALWAYS SEND THE RGB VALUES OF THE COLORS IN THE FOLLOWING FORMAT: [R, G, B]

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -9,67 +9,120 @@ export const PROMPT_INSTRUCTIONS = `
     - Do not explicitly ask for the company name.
     - {content}: ["What is the name of your company or organization?"]
 
-  Question # 2. **Design Selection**:
-    - RENDER the buttons group for user selection USING the "renderButtons" tool:
+  Question # 2. **Tent type Selection**:
+    - ALWAYS RENDER the buttons group for user selection by EXPLICITLY CALLING the "renderButtons" tool:
+      - {assistant multiline prompt in array}
+      - {options}: [
+          { "name": "No Panels", "value": "no-walls" },
+          { "name": "Half Panels with Full Back", "value": "half-walls" },
+        ]
+
+  Question # 3. **Design Selection**:
+    - ALWAYS RENDER the buttons group for user selection by EXPLICITLY CALLING the "renderButtons" tool:
       - {assistant multiline prompt in array}
       - {options}: [
           { "name": "One color for the entire canopy", "value": "Monochrome" },
           { "name": "Separate colors for each print location", "value": "Different Colors" }
         ]
 
-  Question # 3. **Colors Selection**:
-    - ALWAYS USE the renderColorPicker tool for user color selection:
-    - If "Monochrome": 
-      - Base color for the entire tent
-    - If "Different Colors": Sequentially render the color picker for each of the following:
-      - Slope of the tent
-      - Canopy of the tent
-      - Walls of the tent
-    - content = {assistant multiline prompt in array}
-
-  Question # 4. **Pattern Selection**:
-    - RENDER the buttons group for user selection USING the "renderButtons" tool:
-      - {content}: {assistant multiline prompt in array}
-      - {options}: [
-          { "name": "Yes", "value": "Yes" },
-          { "name": "No", "value": "No" }
+  Question # 3.1. **Colors Selection**:
+    - If "Monochrome" selected: 
+      - ALWAYS EXPLICITLY CALL the renderColorPicker tool for user color selection for base color for the entire tent
+    - If "Different Colors" selected: 
+      - ALWAYS RENDER the buttons group for user selection by EXPLICITLY CALLING the "renderButtons" tool for region type selection UNLESS ONLY ONE OPTION IS LEFT TO BE SELECTED:
+        - {assistant multiline prompt in array}
+        - {options}: [
+          { "name": "Peak", "value": "peak" },
+          { "name": "Valence", "value": "valence" },
+          { "name": "Panel", "value": "panel" } (IF Half Panels with Full Back selected)
         ]
-    - If "Yes": 
-      - Sequentially Always use the renderColorPicker tool for user color selection for each of the following with content = {assistant multiline prompt in array}:
-        - Question # 4.1. Secondary color for the pattern
-        - Question # 4.2. Tertiary color for the pattern
+      - Once a region is selected, proceed to Question # 3.2
+      
+      Question # 3.2 **Region Side Color Selection**: (IF AND ONLY IF Different Colors selected and region type selected)
+         - ALWAYS RENDER the buttons group for user selection by EXPLICITLY CALLING the "renderButtons" tool UNLESS ONLY ONE OPTION IS LEFT TO BE SELECTED:
+          - {assistant multiline prompt in array}
+          - {options}: [
+            { "name": "Front", "value": "front" } (IF Half Panels with Full Back and (Peak or Valence selected)),
+            { "name": "Back", "value": "back" },
+            { "name": "Left", "value": "left" },
+            { "name": "Right", "value": "right" }
+          ]
+        - Once a side is selected, proceed to Question # 3.3
+      
+      Question # 3.3 **Region Color Selection**: (IF AND ONLY IF Different Colors selected and region side selected)
+         - ALWAYS Render the color picker by EXPLICITLY CALL the renderColorPicker tool for user color selection for the specific side
+      FLOW:
+        1. User selects a region type from the remaining options.
+        2. Once region selected, User selects a side of the region.
+        3. Once side selected, User selects a color for the side of the region.
+        4. Repeat steps 2 and 3 until all sides of the region are selected.
+        5. Repeat steps 1 through 4 until all regions are selected.
+        6. Once all regions are selected, proceed to the next step.
+        Notes:
+          - STRICTLY follow the above flow.
+          - USE COLOR PICKER for color selection.
+          - USE BUTTONS FOR SIDE and REGION SELECTION.
 
-  Question # 5. **Text Addition**:
-    - Request the text to be added to the tent:
-    - {content}: {assistant multiline prompt in array}
+  Question # 4. **Valences Text**:
+    - ALWAYS USE RENDER the buttons group for user selection:
+      - {options}: [
+        { "name": "Front", "value": "front" },
+        { "name": "Back", "value": "back" },
+        { "name": "Left", "value": "left" },
+        { "name": "Right", "value": "right" },
+      ]
+    - Once THE USER SELECTS A SIDE, MAKE SURE TO ASK THE USER TO ADD TEXT FOR THE SELECTED SIDE ON VALENCE
+    - Once THE USER HAS PROVIDED THE TEXT FOR THE SELECTED SIDE, Display the REMAINING set of options buttons and repeat this process until ONLY ONE option is left.
+    - IF ONLY ONE SIDE IS LEFT, just ask the user to add text for the last side, without displaying the buttons.
+    - DO NOT SHOW THE SELECTED OPTION AGAIN IN THE SIDES OPTIONS
+    - NEVER REPEAT WITH SAME NUMBER OF OPTIONS  
+    - ONCE ALL SIDES ARE SELECTED, PROCEED TO THE NEXT QUESTION
 
-  Question # 6. **Logo Upload**:
+  Question # 5. **Logo Upload**:
     - Prompt the user to upload their logo:
     - {content}: {assistant multiline prompt in array}
 
-    **Final Confirmation:**
-    - Render the buttons to ask the user to generate mockups or make changes in the below format:
+    **Final Summary and Confirmation:**
+    - ALWAYS RENDER the buttons by EXPLICITLY CALLING the "renderButtons" tool to ask the user to generate mockups or make changes in the below format:
       {content}: [
         "Here is the summary of your selections:",
         "- Company Name: \${companyName}",
+        "- Canopy Type: \${tentType}",
         "- Design Type: \${designType}",
         "- Colors:",
-        "  - Slope: \${slopeColorName}",
-        "  - Canopy: \${canopyColorName}",
-        "  - Walls: \${wallColorName}",
-        "- Patterned Walls: \${patternedWallsName}",
-        "  - Secondary Color: \${secondaryColorName}",
-        "  - Tertiary Color: \${tertiaryColorName}",
-        "- Text: \${text}",
-        "- Logo: ![Logo](logo.image)"
+        designType === "MONOCHROME" ? 
+          "  - Peak: \${slopeColorName}",
+          "  - Valence: \${canopyColorName}",
+          "  - Panels: \${wallColorName}"
+        :
+        "  - Peak",
+            - Front: \${frontSlopeColorName}",
+            - Back: \${backSlopeColorName}",
+            - Left: \${leftSlopeColorName}",
+            - Right: \${rightSlopeColorName}",
+          "  - Valence",
+            - Front: \${frontCanopyColorName}",
+            - Back: \${backCanopyColorName}",
+            - Left: \${leftCanopyColorName}",
+            - Right: \${rightCanopyColorName}",
+          "  - Panels", (IF tentType === "half-walls")
+            - Back: \${backWallColorName}",
+            - Left: \${leftWallColorName}",
+            - Right: \${rightWallColorName}",
+        "- Text",
+          - Front: \${frontText}",
+          - Back: \${backText}",
+          - Left: \${leftText}",
+          - Right: \${rightText}",
+        "- Logo: <img src="logo.image" alt="Logo" width="150" height="150" />"
       ]
       - {options}: [
           { "name": "Yes, generate mockups", "value": "Yes" },
           { "name": "No, I need to make changes", "value": "No" }
         ]
-      - If the user selectes "No, I need to make changes", ask the user what he would like to change.
-        - When the user has made the changes repeat the confirmation step along with the buttons.
-      - If the user selectes "Yes, generate mockups", generate the mockups using the generateCanopyMockups function and display them to the user.
+      - If the user selects "No, I need to make changes", ask the user what he would like to change.
+        - When the user has made the changes repeat the confirmation step along with EXPLICITLY CALLING the "renderButtons" tool.
+      - If the user selects "Yes, generate mockups", EXPLICITLY CALL the generateCanopyMockups function and display them to the user.
 
   ** Questions Guidelines:**
     - Ask one question at a time.
@@ -78,37 +131,26 @@ export const PROMPT_INSTRUCTIONS = `
     - Never display summary except for the final confirmation step.
     - KEEP TRACK OF THE QUESTIONS ASKED WITH THE USER INPUTS AND ASK THE NEXT QUESTION BASED ON THE PREVIOUS INPUTS.
     - NEVER STOP IN BETWEEN THE QUESTIONS once the user response has been received.
-    - If the user has not provided an input for a question, ask the same question again.
-    - If the user input is not relevant or meaningful, ask the user to confirm his input. Once the user confirms the input, proceed to the next question.
-      - This rule does not apply to color inputs and option based questions responses.
-    - NEVER show colors in the questions, especially in RGB format.
     - Always show the name of the selected option rather than value in the questions if needed.
     - For sequential questions, ask one question at a time and wait for the user response before asking the next question.
     - For sequential color inputs, ask one color input at a time and wait for the user response before asking the next color input.
     - Never show the user any technical details or error messages.
 
-  **Input Guidelines:**
-    - For color inputs, accept the colors in RGB format and convert them to their descriptive when displaying to user.
-      - Save descriptive color names in the following format to be use consistently across multiple responses
-        - slopeColorName
-        - canopyColorName
-        - wallColorName
-        - secondaryColorName
-        - tertiaryColorName
-    - For text inputs, accept the text in string format and display them as is when displaying to user.
-  
+   ** Input Guidelines:**
+    - If the user has not provided an input for a question, ask the same question again.
+    - If the user input is not relevant or meaningful, ask the user to confirm his input. Once the user confirms the input, proceed to the next question.
+      - This rule does not apply to color inputs and option based questions responses.
+    - ACCEPT colors in RGB values.
+
   ** Tool Guidelines:**
-    - Whenever asking the user a closed ended question, render the options using the renderButtons tool function. Below are the questions STRICTLY requiring the renderButtons tool function:
-      - Question#2, Question#4, and in confirmation step
-    - Whenever asking the user to select a color, render the color picker using the renderColorPicker tool function. Below are the questions STRICTLY requiring the renderButtons tool function:
-     - Question#3, Question#4.1 and Question#4.2
+    - EXPLICITLY CALL the appropriate tool function at EACH step - never skip a tool call.
+    - Whenever asking the user a closed ended question, EXPLICITLY CALL the renderButtons tool function. Below are the questions STRICTLY requiring the renderButtons tool function:
+      - Question#2, Question#3(WHEN different colors SELECTED), Question#3.1 and in confirmation step
+    - Whenever asking the user to select a color, EXPLICITLY CALL the renderColorPicker tool function. Below are the questions STRICTLY requiring the renderColorPicker tool function:
+     - Question#3(WHEN monochrome SELECTED), Question#3.2
     - **generateCanopyMockups tool function**
-      - Use the generateCanopyMockups tool function to generate the mockups of the canopy whenever the user confirms the inputs.
-      - Always use the BGR format for all color inputs.
-      - The format MUST STRICTLY be: \'[b, g, r]\' (e.g., [255, 0, 0] for blue).
-      - Do not use descriptive color names, RGB format, or any other format.
-      - Correct: [255, 0, 0]
-      - Incorrect: "blue", "rgb(0,0,255)", b,g,r or [r, g, b].
+      - EXPLICITLY CALL the generateCanopyMockups tool function to generate the mockups of the canopy whenever the user confirms the inputs.
+      - WHILE SENDING COLORS TO THE generateCanopyMockups TOOL FUNCTION, ALWAYS SEND THE RGB VALUES OF THE COLORS IN THE FOLLOWING FORMAT: [R, G, B]
 
   **Editing Guidelines:**
     - For text, logo, or company name changes, only request updated inputs for the specified fields.

--- a/lib/ai-tools/schemas.ts
+++ b/lib/ai-tools/schemas.ts
@@ -28,20 +28,50 @@ export const CustomCanopyToolSchema = z.object({
   payload: z
     .object({
       companyName: z.string().describe('Name of the company or organization'),
-      isPatterned: z
-        .boolean()
-        .describe('Will a pattern be included on the tent?'),
-      tentColors: z
+      tentType: z.string().describe('Type of Tent'),
+      peaks: z
         .object({
-          slope: z.string().describe('Color of the slope'),
-          canopy: z.string().describe('Color of the canopy'),
-          walls_primary: z.string().describe('Primary color of the walls'),
-          walls_secondary: z.string().describe('Secondary color of the walls'),
-          walls_tertiary: z.string().describe('Tertiary color of the walls')
+          front: z.string().describe('Color of peak front'),
+          back: z.string().describe('Color of peak back'),
+          left: z.string().describe('Color of peak left'),
+          right: z.string().describe('Color of peak right')
         })
-        .describe('Colors of the tent')
+        .describe('Colors of the peaks')
         .required(),
-      text: z.string().describe('Text to be displayed on the tent banner'),
+      valences: z
+        .object({
+          front: z.string().describe('Color of valence front'),
+          back: z.string().describe('Color of valence back'),
+          left: z.string().describe('Color of valence left'),
+          right: z.string().describe('Color of valence right')
+        })
+        .describe('Colors of the valences')
+        .required(),
+      panels: z
+        .object({
+          left: z.string().describe('Color of panel left'),
+          right: z.string().describe('Color of panel right'),
+          back: z.string().describe('Color of panel back')
+        })
+        .describe('Colors of the valences')
+        .required(),
+      valencesTexts: z
+        .object({
+          front: z
+            .string()
+            .describe('Text to be displayed on the front of the tent banner'),
+          back: z
+            .string()
+            .describe('Text to be displayed on the back of the tent banner'),
+          left: z
+            .string()
+            .describe('Text to be displayed on the left of the tent banner'),
+          right: z
+            .string()
+            .describe('Text to be displayed on the right of the tent banner')
+        })
+        .describe('Details of the text to be displayed on the tent banner')
+        .required(),
       logo: z
         .object({
           image: z.string().describe('The image file uploaded'),

--- a/lib/ai-tools/schemas.ts
+++ b/lib/ai-tools/schemas.ts
@@ -2,12 +2,20 @@ import { TENT_MOCKUP_VALIDATIONS } from '@/app/constants'
 import { z } from 'zod'
 
 export const ButtonToolSchema = z.object({
-  content: z.array(z.string()).describe('The prompt for the button group'),
+  content: z.string().describe('Asking user to choose from the options'),
   options: z
     .array(
       z.object({
         name: z.string().describe('The name for the button'),
-        value: z.string().describe('The value for the button')
+        value: z.string().describe('The value for the button'),
+        selected: z
+          .boolean()
+          .describe('The selected state for the button')
+          .default(false),
+        edit: z
+          .boolean()
+          .describe('The edit state for the button')
+          .default(false)
       })
     )
     .describe('The options to display')
@@ -15,16 +23,63 @@ export const ButtonToolSchema = z.object({
 })
 
 export const ColorPickerToolSchema = z.object({
-  content: z.array(z.string()).describe('The prompt for the button group')
+  content: z.string().describe('Asking user to select color')
+})
+
+export const ChatTextInputGroupSchema = z.object({
+  content: z.string().describe('Asking user to input details'),
+  inputFields: z
+    .array(
+      z.object({
+        label: z.string().describe('The label for the input field'),
+        value: z.string().describe('The value for the input field')
+      })
+    )
+    .describe('The input fields to display')
+    .nonempty()
+})
+
+export const ColorLabelPickerSetSchema = z.object({
+  content: z.string().describe('Asking user to select multi color'),
+  fieldColors: z
+    .array(
+      z.object({
+        name: z.string().describe('The name for the color picker'),
+        label: z.string().describe('The label for the color picker'),
+        color: z.object({
+          name: z.string().describe('The color name'),
+          value: z.string().describe('The color value')
+        })
+      })
+    )
+    .describe('The color pickers to display')
+    .nonempty()
 })
 
 export const CustomCanopyToolSchema = z.object({
   content: z
     .array(z.string())
     .describe(
-      'The content to be displayed for the canopy tool while waiting and after the image is generated'
+      'The content to be displayed for the canopy tool while waiting, after the image and while displaying add-ons options.'
     )
-    .length(2),
+    .length(3),
+  options: z
+    .array(
+      z.object({
+        name: z.string().describe('The name for the button'),
+        value: z.string().describe('The value for the button'),
+        selected: z
+          .boolean()
+          .describe('Whether the button is selected')
+          .default(false),
+        edit: z
+          .boolean()
+          .describe('The edit state for the button')
+          .default(false)
+      })
+    )
+    .describe('The options to display')
+    .nonempty(),
   payload: z
     .object({
       companyName: z.string().describe('Name of the company or organization'),
@@ -47,11 +102,11 @@ export const CustomCanopyToolSchema = z.object({
         })
         .describe('Colors of the valences')
         .required(),
-      panels: z
+      walls: z
         .object({
-          left: z.string().describe('Color of panel left'),
-          right: z.string().describe('Color of panel right'),
-          back: z.string().describe('Color of panel back')
+          left: z.string().describe('Color of wall left'),
+          right: z.string().describe('Color of wall right'),
+          back: z.string().describe('Color of wall back')
         })
         .describe('Colors of the valences')
         .required(),
@@ -89,7 +144,10 @@ export const CustomCanopyToolSchema = z.object({
         .describe('Color of the text to be displayed on the tent banner'),
       font: z
         .string()
-        .describe('Font of the text to be displayed on the tent banner')
+        .describe('Font of the text to be displayed on the tent banner'),
+      tableColor: z
+        .string()
+        .describe('Color of the table to be displayed on the tent banner')
     })
     .describe('Details of the tent to be generated')
     .required()

--- a/lib/ai-tools/tool-functions.tsx
+++ b/lib/ai-tools/tool-functions.tsx
@@ -4,16 +4,21 @@ import { ToolContent } from 'ai'
 import {
   ButtonToolSchema,
   ColorPickerToolSchema,
-  CustomCanopyToolSchema
+  CustomCanopyToolSchema,
+  ChatTextInputGroupSchema,
+  ColorLabelPickerSetSchema
 } from './schemas'
 import { Carousal } from '@/components/carousel'
 import { BotCard, BotMessage } from '@/components/stocks/message'
 import { ChatRadioButtonWrapper } from '@/components/chat-radio-buttons-wrapper'
 import { ChatColorPickerWrapper } from '@/components/chat-color-picker-wrapper'
 import { generateTentMockupsApi } from '../redux/apis/tent-mockup-prompt'
-import { Roles, TentMockUpPrompt } from '../types'
+import { MockupResponse, Roles, TentMockUpPrompt } from '../types'
 import { TOOL_FUNCTIONS } from './constants'
 import { modifyAIState } from './utils'
+import { ChatTextInputGroup } from '@/components/chat-text-input-group'
+import { ColorLabelPickerSet } from '@/components/color-label-picker-set'
+import ChatActionMultiSelector from '@/components/chat-action-multi-selector'
 
 function modifyToolAIState(history: any, content: ToolContent) {
   modifyAIState(history, {
@@ -30,28 +35,21 @@ export function renderButtonsTool(history: any, messageId: string) {
       content,
       options
     }: z.infer<typeof ButtonToolSchema>) {
-      const message = content.join('\n')
       modifyToolAIState(history, [
         {
           toolCallId: messageId,
           toolName: TOOL_FUNCTIONS.RENDER_BUTTONS,
           result: {
-            message,
+            message: content,
             props: { options }
           }
         }
       ] as ToolContent)
 
-      await new Promise(resolve => setTimeout(resolve, 1000))
-
       return (
-        <BotMessage
-          key={messageId}
-          content={message}
-          children={
-            <ChatRadioButtonWrapper options={options} messageId={messageId} />
-          }
-        />
+        <BotMessage key={messageId} content={content}>
+          <ChatRadioButtonWrapper options={options} messageId={messageId} />
+        </BotMessage>
       )
     }
   }
@@ -64,59 +62,124 @@ export function renderColorPickerTool(history: any, messageId: string) {
     generate: async function ({
       content
     }: z.infer<typeof ColorPickerToolSchema>) {
-      const message = content.join('\n')
       modifyToolAIState(history, [
         {
           toolCallId: messageId,
           toolName: TOOL_FUNCTIONS.RENDER_COLOR_PICKER,
           result: {
-            message
+            message: content
           }
         }
       ] as ToolContent)
-      await new Promise(resolve => setTimeout(resolve, 1000))
 
       return (
-        <BotMessage
-          key={messageId}
-          content={message}
-          children={<ChatColorPickerWrapper messageId={messageId} />}
-        />
+        <BotMessage key={messageId} content={content}>
+          <ChatColorPickerWrapper messageId={messageId} />
+        </BotMessage>
       )
     }
   }
 }
 
+export function renderTextInputGroup(history: any, messageId: string) {
+  return {
+    description: 'Renders the text input with label for user input',
+    parameters: ChatTextInputGroupSchema,
+    generate: async function ({
+      content,
+      inputFields
+    }: z.infer<typeof ChatTextInputGroupSchema>) {
+      modifyToolAIState(history, [
+        {
+          toolCallId: messageId,
+          toolName: TOOL_FUNCTIONS.RENDER_TEXT_INPUT_GROUP,
+          result: {
+            message: content,
+            props: { inputFields }
+          }
+        }
+      ] as ToolContent)
+
+      return (
+        <BotMessage key={messageId} content={content}>
+          <ChatTextInputGroup inputFields={inputFields} messageId={messageId} />
+        </BotMessage>
+      )
+    }
+  }
+}
+
+export function renderColorLabelPickerSet(history: any, messageId: string) {
+  return {
+    description: 'Renders the multi color picker with label for user input',
+    parameters: ColorLabelPickerSetSchema,
+    generate: async function ({
+      content,
+      fieldColors
+    }: z.infer<typeof ColorLabelPickerSetSchema>) {
+      modifyToolAIState(history, [
+        {
+          toolCallId: messageId,
+          toolName: TOOL_FUNCTIONS.RENDER_COLOR_LABEL_PICKER_SET,
+          result: {
+            message: content,
+            props: { fieldColors }
+          }
+        }
+      ] as ToolContent)
+      await new Promise(resolve => setTimeout(resolve, 1000))
+      return (
+        <BotMessage key={messageId} content={content}>
+          <ColorLabelPickerSet
+            fieldColors={fieldColors}
+            messageId={messageId}
+          />
+        </BotMessage>
+      )
+    }
+  }
+}
 export function generateCanopyMockups(history: any, messageId: string) {
   return {
     description: 'Generates the images for canopy tents based on user details',
     parameters: CustomCanopyToolSchema,
     generate: async function* ({
       content,
+      options,
       payload
     }: z.infer<typeof CustomCanopyToolSchema>) {
       yield <BotCard>{content[0]}</BotCard>
       try {
-        const mockups: { fileName: string; data: string }[] =
-          await generateTentMockupsApi({
-            ...(payload as TentMockUpPrompt),
-            id: history.get().id
-          })
-        // modifyToolAIState(history, [
-        //   {
-        //     toolCallId: messageId,
-        //     toolName: TOOL_FUNCTIONS.GENERATE_CANOPY_MOCKUPS,
-        //     result: {
-        //       message: content[1],
-        //       props: { mockups }
-        //     }
-        //   }
-        // ] as ToolContent)
+        console.log('payload', payload)
+        const mockups: MockupResponse = await generateTentMockupsApi({
+          ...(payload as TentMockUpPrompt),
+          id: history.get().id
+        })
+        modifyToolAIState(history, [
+          {
+            toolCallId: messageId,
+            toolName: TOOL_FUNCTIONS.GENERATE_CANOPY_MOCKUPS,
+            result: {
+              message: content[1],
+              props: {
+                mockups,
+                options,
+                action: 'Place Order',
+                selectorName: 'Add-Ons'
+              }
+            }
+          }
+        ] as ToolContent)
         return (
-          <BotMessage
-            content={content[1]}
-            children={<Carousal mockups={mockups} />}
-          />
+          <BotMessage content={content[1]}>
+            <Carousal mockups={mockups} />
+            <ChatActionMultiSelector
+              action="Place Order"
+              selectorName="Add-Ons"
+              options={options}
+              messageId={messageId}
+            />
+          </BotMessage>
         )
       } catch (err) {
         const error = (err as Error).message
@@ -139,6 +202,8 @@ export const getToolFunctions = (history: any, messageId: string) => {
   return {
     renderButtons: renderButtonsTool(history, messageId),
     renderColorPicker: renderColorPickerTool(history, messageId),
+    renderColorLabelPickerSet: renderColorLabelPickerSet(history, messageId),
+    renderTextInputGroup: renderTextInputGroup(history, messageId),
     generateCanopyMockups: generateCanopyMockups(history, messageId)
   }
 }

--- a/lib/ai-tools/tool-functions.tsx
+++ b/lib/ai-tools/tool-functions.tsx
@@ -1,19 +1,19 @@
 import React from 'react'
-import { BotCard, BotMessage } from '@/components/stocks/message'
-import { ChatRadioButtonWrapper } from '@/components/chat-radio-buttons-wrapper'
-import { ChatColorPickerWrapper } from '@/components/chat-color-picker-wrapper'
 import { z } from 'zod'
+import { ToolContent } from 'ai'
 import {
   ButtonToolSchema,
   ColorPickerToolSchema,
   CustomCanopyToolSchema
 } from './schemas'
 import { Carousal } from '@/components/carousel'
+import { BotCard, BotMessage } from '@/components/stocks/message'
+import { ChatRadioButtonWrapper } from '@/components/chat-radio-buttons-wrapper'
+import { ChatColorPickerWrapper } from '@/components/chat-color-picker-wrapper'
 import { generateTentMockupsApi } from '../redux/apis/tent-mockup-prompt'
 import { Roles, TentMockUpPrompt } from '../types'
 import { TOOL_FUNCTIONS } from './constants'
 import { modifyAIState } from './utils'
-import { ToolContent } from 'ai'
 
 function modifyToolAIState(history: any, content: ToolContent) {
   modifyAIState(history, {
@@ -102,7 +102,6 @@ export function generateCanopyMockups(history: any, messageId: string) {
             ...(payload as TentMockUpPrompt),
             id: history.get().id
           })
-        console.log('add mockups', mockups)
         // modifyToolAIState(history, [
         //   {
         //     toolCallId: messageId,

--- a/lib/ai-tools/utils.tsx
+++ b/lib/ai-tools/utils.tsx
@@ -4,13 +4,16 @@ import { ChatRadioButtonWrapper } from '@/components/chat-radio-buttons-wrapper'
 import { ChatColorPickerWrapper } from '@/components/chat-color-picker-wrapper'
 import { Chat, ClientMessage, Roles, ToolCallResult } from '@/lib/types'
 import { CHAT, IMAGE } from '@/app/constants'
-import { getRGBColorName, isValidJson, nanoid } from '@/lib/utils'
+import { isValidJson, nanoid } from '@/lib/utils'
 import {
   INITIAL_CHAT_MESSAGE,
   LOGO_MSG_REGEX,
   TOOL_FUNCTIONS
 } from './constants'
 import { Carousal } from '@/components/carousel'
+import { ChatTextInputGroup } from '@/components/chat-text-input-group'
+import { ColorLabelPickerSet } from '@/components/color-label-picker-set'
+import ChatActionMultiSelector from '@/components/chat-action-multi-selector'
 
 const createInitialAIState = (): Chat => {
   const chatId = nanoid()
@@ -61,30 +64,33 @@ const modifyAIState = (
   }
 }
 
-const getToolMessage = (
-  content: ToolContent,
-  selectedOption?: string
-): ClientMessage => {
+const getToolMessage = (content: ToolContent): ClientMessage => {
   const { toolCallId, toolName, result } = content[0]
   const { message, props } = result as ToolCallResult
+
   const toolComponent = (() => {
     switch (toolName) {
       case TOOL_FUNCTIONS.RENDER_BUTTONS:
-        return (
-          <ChatRadioButtonWrapper
-            selectedOption={selectedOption}
-            messageId={toolCallId}
-            {...props}
-          />
-        )
+        return <ChatRadioButtonWrapper messageId={toolCallId} {...props} />
 
       case TOOL_FUNCTIONS.RENDER_COLOR_PICKER:
         return <ChatColorPickerWrapper messageId={toolCallId} />
 
+      case TOOL_FUNCTIONS.RENDER_TEXT_INPUT_GROUP:
+        return <ChatTextInputGroup messageId={toolCallId} {...props} />
+
+      case TOOL_FUNCTIONS.RENDER_COLOR_LABEL_PICKER_SET:
+        return <ColorLabelPickerSet messageId={toolCallId} {...props} />
+
+      case TOOL_FUNCTIONS.GENERATE_CANOPY_MOCKUPS:
+        return (
+          <>
+            <Carousal {...props} />
+            <ChatActionMultiSelector {...props} messageId={toolCallId} />
+          </>
+        )
+
       default:
-        if (props) {
-          return <Carousal {...props} />
-        }
         return null
     }
   })()
@@ -93,26 +99,28 @@ const getToolMessage = (
     id: toolCallId,
     role: Roles.tool,
     display: (
-      <BotMessage key={toolCallId} content={message} children={toolComponent} />
+      <BotMessage key={toolCallId} content={message}>
+        {toolComponent}
+      </BotMessage>
     )
   }
 }
 
-const getClientMessage = (
-  message: CoreMessage,
-  selectedOption?: string
-): ClientMessage => {
+const getClientMessage = (message: CoreMessage): ClientMessage => {
   const { role, content } = message
   const id = nanoid()
+
   switch (role) {
     case Roles.tool:
-      return getToolMessage(content as ToolContent, selectedOption)
+      return getToolMessage(content)
+
     case Roles.assistant:
       return {
         id,
         role: Roles.assistant,
         display: <BotMessage key={id} content={content as string} />
       }
+
     default:
       return {
         id,
@@ -125,39 +133,44 @@ const getClientMessage = (
 const getClientMessages = (messages: CoreMessage[]): ClientMessage[] => {
   const clientMessages: ClientMessage[] = []
   let i = 0
-
   while (i < messages.length) {
     const currentMessage = messages[i]
     const nextMessage = messages[i + 1]
     const previousMessage = messages[i - 1]
-
-    if (
-      currentMessage.role === Roles.tool &&
-      nextMessage?.role === Roles.user
-    ) {
-      const toolContent = currentMessage.content as ToolContent
-      if (toolContent[0].toolName === TOOL_FUNCTIONS.RENDER_BUTTONS) {
-        clientMessages.push(
-          getClientMessage(currentMessage, nextMessage.content as string)
-        )
-        i += 2
-        continue
-      }
-    }
-
     if (
       currentMessage.role === Roles.user &&
-      i - 1 >= 0 &&
+      previousMessage &&
       (previousMessage.content as ToolContent)[0]?.toolName ===
         TOOL_FUNCTIONS.RENDER_COLOR_PICKER &&
       isValidJson(currentMessage.content as string)
     ) {
-      currentMessage.content = getRGBColorName(
+      currentMessage.content = JSON.parse(
         currentMessage.content as string
-      ) as string
+      ).colorName
+    } else if (
+      currentMessage.role === Roles.tool &&
+      nextMessage?.role === Roles.user &&
+      currentMessage.content[0].toolName !==
+        TOOL_FUNCTIONS.RENDER_COLOR_PICKER &&
+      isValidJson(nextMessage.content as string)
+    ) {
+      currentMessage.content = [
+        {
+          ...currentMessage.content[0],
+          result: {
+            ...(currentMessage.content[0].result as ToolCallResult),
+            props: {
+              ...(currentMessage.content[0].result as ToolCallResult).props,
+              ...JSON.parse(nextMessage.content as string)
+            }
+          }
+        }
+      ]
+
+      i = i + 1
     }
     clientMessages.push(getClientMessage(currentMessage))
-    i++
+    i = i + 1
   }
 
   return clientMessages
@@ -165,15 +178,18 @@ const getClientMessages = (messages: CoreMessage[]): ClientMessage[] => {
 
 export const isLastFileUploadMessage = (message: CoreMessage): boolean => {
   return (
-    message &&
-    message.role === Roles.assistant &&
+    message?.role === Roles.assistant &&
     LOGO_MSG_REGEX.test(message.content as string)
   )
 }
 
-export const customizeCoreMessages = (messages: any[]) => {
+export const customizeCoreMessages = (messages: any[]): CoreMessage[] => {
   const updatedMessages = messages.map(message => {
-    if (typeof message.content === 'object' && IMAGE in message.content[0]) {
+    if (
+      typeof message.content === 'object' &&
+      message.content[0] &&
+      IMAGE in message.content[0]
+    ) {
       message.content = JSON.stringify(message.content)
     }
     return message

--- a/lib/redux/apis/tent-mockup-prompt.ts
+++ b/lib/redux/apis/tent-mockup-prompt.ts
@@ -63,9 +63,7 @@ export const generateTentMockupsApi = async (
     }
     const logoFile = await fetchLogoFile(tentMockupPrompt.logo)
     const formData = createFormData({ ...tentMockupPrompt, logoFile })
-    console.log('add formData', formData)
     const zipBlob = await fetchMockupZip(formData)
-    console.log('add zipBlob', zipBlob)
     return await extractImagesFromZip(zipBlob)
   } catch (error) {
     throw new Error((error as Error).message || 'Something went wrong!')

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -66,13 +66,21 @@ export interface TentColorRegions {
   walls_secondary: string
   walls_tertiary: string
 }
+export interface TentSides {
+  left: string
+  right: string
+  back: string
+  front?: string
+}
 
 export interface TentMockUpPrompt {
   id: string
   companyName: string
-  isPatterned: boolean
-  tentColors: TentColorRegions
-  text: string
+  tentType: string
+  peaks: TentSides
+  valences: TentSides
+  panels: TentSides
+  valencesTexts: TentSides
   logo: ImagePart
   font: string
   fontColor: string
@@ -85,6 +93,12 @@ export enum Roles {
   'assistant' = 'assistant',
   'system' = 'system',
   'tool' = 'tool'
+}
+
+export enum Types {
+  'full-walls' = 'full-walls',
+  'half-walls' = 'half-walls',
+  'no-walls' = 'no-walls'
 }
 
 export type TentColorConfig = {
@@ -130,4 +144,10 @@ export type FieldErrors = {
 export interface GuidanceImage {
   filename: string
   data: string
+}
+
+export type Color = {
+  name: string
+  rgb: string
+  tailwind: string
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -9,7 +9,6 @@ export interface ClientMessage {
   id: string
   role: Roles
   display: React.ReactNode
-  selectedOption?: string
 }
 
 export interface ToolCallResult {
@@ -79,11 +78,12 @@ export interface TentMockUpPrompt {
   tentType: string
   peaks: TentSides
   valences: TentSides
-  panels: TentSides
+  walls: TentSides
   valencesTexts: TentSides
   logo: ImagePart
   font: string
   fontColor: string
+  tableColor: string
 }
 
 export type ChatResponse = Chat | null | { error: string }
@@ -120,8 +120,10 @@ export enum ResultCode {
 
 export type MockupResponse = {
   front: PutBlobResult
+  table: PutBlobResult
   'half-wall': PutBlobResult
   'top-view': PutBlobResult
+  'no-walls': PutBlobResult
 }
 
 export type ActionResult = {
@@ -146,8 +148,9 @@ export interface GuidanceImage {
   data: string
 }
 
-export type Color = {
+export type EditableOption = {
   name: string
-  rgb: string
-  tailwind: string
+  value: string
+  selected: boolean
+  edit?: boolean
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -143,9 +143,9 @@ export type FieldErrors = {
   [x: symbol]: string | undefined
 }
 
-export interface GuidanceImage {
+export interface Image {
   filename: string
-  data: string
+  url: string
 }
 
 export type EditableOption = {

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -127,7 +127,7 @@ export function subMonths(date: Date, amount: number) {
   return newDate
 }
 export function getColorName(hexColor: string): string | null {
-  const namedColor = namer(hexColor).pantone[0]
+  const namedColor = namer(hexColor).x11[0]
   return namedColor ? namedColor.name : null
 }
 

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -127,7 +127,7 @@ export function subMonths(date: Date, amount: number) {
   return newDate
 }
 export function getColorName(hexColor: string): string | null {
-  const namedColor = namer(hexColor).basic[0]
+  const namedColor = namer(hexColor).pantone[0]
   return namedColor ? namedColor.name : null
 }
 

--- a/lib/utils/tent-mockup.ts
+++ b/lib/utils/tent-mockup.ts
@@ -8,33 +8,29 @@ interface TentMockUpPromptFormData extends TentMockUpPrompt {
 export const createFormData = (
   mockUpPrompt: TentMockUpPromptFormData
 ): FormData => {
-  const { logoFile, tentColors, text, isPatterned } = mockUpPrompt
+  const { logoFile, tentType, peaks, panels, valences, valencesTexts } =
+    mockUpPrompt
   const formRequestBody = new FormData()
 
-  formRequestBody.append(
-    'slope_color',
-    tentColors.slope || COLORS.LIGHT_GREY_COLOR
-  )
-  formRequestBody.append(
-    'canopy_color',
-    tentColors.canopy || COLORS.LIGHT_GREY_COLOR
-  )
-  formRequestBody.append(
-    'walls_primary_color',
-    tentColors.walls_primary || COLORS.LIGHT_GREY_COLOR
-  )
-  formRequestBody.append(
-    'walls_secondary_color',
-    tentColors.walls_secondary || COLORS.LIGHT_GREY_COLOR
-  )
-  formRequestBody.append(
-    'walls_tertiary_color',
-    tentColors.walls_tertiary || COLORS.LIGHT_GREY_COLOR
-  )
-  formRequestBody.append('text', text)
+  Object.entries(peaks).forEach(([key, value]) => {
+    formRequestBody.append(`peaks_${key}`, value)
+  })
+
+  if (tentType !== 'no-walls') {
+    Object.entries(panels).forEach(([key, value]) => {
+      formRequestBody.append(`panels_${key}`, value)
+    })
+  }
+  Object.entries(valences).forEach(([key, value]) => {
+    formRequestBody.append(`valences_${key}`, value)
+  })
+
+  Object.entries(valencesTexts).forEach(([key, value]) => {
+    formRequestBody.append(`${key}_text`, value)
+  })
+
   formRequestBody.append('logo', logoFile)
   formRequestBody.append('text_color', COLORS.BLACK_COLOR)
-  formRequestBody.append('patterned', `${isPatterned}`)
 
   return formRequestBody
 }

--- a/lib/utils/tent-mockup.ts
+++ b/lib/utils/tent-mockup.ts
@@ -8,8 +8,16 @@ interface TentMockUpPromptFormData extends TentMockUpPrompt {
 export const createFormData = (
   mockUpPrompt: TentMockUpPromptFormData
 ): FormData => {
-  const { logoFile, tentType, peaks, panels, valences, valencesTexts } =
-    mockUpPrompt
+  const {
+    id,
+    logoFile,
+    tentType,
+    tableColor,
+    peaks,
+    walls,
+    valences,
+    valencesTexts
+  } = mockUpPrompt
   const formRequestBody = new FormData()
 
   Object.entries(peaks).forEach(([key, value]) => {
@@ -17,7 +25,7 @@ export const createFormData = (
   })
 
   if (tentType !== 'no-walls') {
-    Object.entries(panels).forEach(([key, value]) => {
+    Object.entries(walls).forEach(([key, value]) => {
       formRequestBody.append(`panels_${key}`, value)
     })
   }
@@ -31,6 +39,8 @@ export const createFormData = (
 
   formRequestBody.append('logo', logoFile)
   formRequestBody.append('text_color', COLORS.BLACK_COLOR)
+  if (tableColor) formRequestBody.append('table_color', tableColor)
+  formRequestBody.append('output_dir', `chat:${id}`)
 
   return formRequestBody
 }


### PR DESCRIPTION
## Description

This PR corresponds to the following tasks
- [Frontend-FE-Mockup-Add-Ons-Add-Table-Options-in-System-Instructions](https://www.notion.so/conradlabshq/Frontend-FE-Mockup-Add-Ons-Add-Table-Options-in-System-Instructions-1ba512441d3c804e8532d80aca1cb702?pvs=4)
- [Frontend-FE-UI-Updates-for-Enhanced-Flow-and-Interactive-Features](https://www.notion.so/conradlabshq/Frontend-FE-UI-Updates-for-Enhanced-Flow-and-Interactive-Features-1ba512441d3c807084f5ede837763906?pvs=4)

This pull request introduces several enhancements to the add-ons, mockup generation workflow, and order process. It also includes support for a new table add-on with payload handling.  

### Changes Made

#### Add-ons Enhancements  
- Added a text input group and color picker label set to support multiple inputs in a single message.  
- Introduced `renderColorLabelPickerSet` and `renderTextInputGroup` tool functions with schemas for multi-input functionality.  
- Added support for a table add-on, including proper payload handling.  
- Created a dedicated section for managing add-ons.  

#### Mockups Enhancements  
- Modified the response to handle URLs instead of zip files.  
- Enabled users to initiate multiple mockup generation sessions.  
- Started mockup generation with company **NAME**, **LOGO**, and **COLOR** as defaults.  

#### Order Process Enhancements  
- Added a "Place Order" button to collect user email and phone number during order finalization.  

#### UI Improvements  
- Made radio buttons editable.  

## Screenshots
Please refer to the following screenshots
![screencapture-localhost-3000-chat-Ved8QH3-2025-03-26-12_53_58](https://github.com/user-attachments/assets/9716f7f1-da20-405a-817f-e819133bf6a7)
