### PR TITLE
Feat(api): implement zip download functionality for images

### DIFF
--- a/app/api/images-download/route.ts
+++ b/app/api/images-download/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server'
+import JSZip from 'jszip'
+import { Image } from '@/lib/types'
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  const { images }: { images: Image[] } = body
+
+  if (!Array.isArray(images)) {
+    return NextResponse.json(
+      { error: 'Images must be an array.' },
+      { status: 400 }
+    )
+  }
+
+  const zip = new JSZip()
+
+  try {
+    for (const image of images) {
+      const { filename, url, contentType } = image
+
+      let fileData: ArrayBuffer
+
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
+      }
+      fileData = await response.arrayBuffer()
+      const extension = contentType ? `.${contentType.split('/')?.[1]}` : ''
+      zip.file(filename + extension, fileData)
+    }
+
+    const zipContent = await zip.generateAsync({ type: 'nodebuffer' })
+
+    return new NextResponse(zipContent, {
+      headers: {
+        'Content-Type': 'application/zip',
+        'Content-Disposition': 'attachment; filename="images.zip"'
+      }
+    })
+  } catch (error) {
+    console.error('Error:', error)
+    return NextResponse.json(
+      { error: 'Failed to process images.' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -48,6 +48,7 @@ export const MOCKUP_TYPES = {
   'no-walls': 'No Walls',
   table: 'Table'
 }
+export const DOWNLOAD_ZIP_NAME = 'images'
 
 export const GUIDANCE_IMAGE_URLS = {
   'front-dark':

--- a/components/carousel.tsx
+++ b/components/carousel.tsx
@@ -10,7 +10,9 @@ import {
 } from '@/components/ui/tooltip'
 import PreviewCarousel from './preview-carousel'
 import { Image, MockupResponse } from '@/lib/types'
-import { MOCKUP_TYPES } from '@/app/constants'
+import { DOWNLOAD_ZIP_NAME, MOCKUP_TYPES } from '@/app/constants'
+import { PinBottomIcon } from '@radix-ui/react-icons'
+import { downloadImages } from '@/lib/redux/apis/files'
 
 export const Carousal = ({
   mockups,
@@ -25,6 +27,7 @@ export const Carousal = ({
   useEffect(() => {
     const images: Image[] = Object.entries(mockups).map(([key, value]) => ({
       url: value.url,
+      contentType: value.contentType,
       filename:
         key in MOCKUP_TYPES
           ? MOCKUP_TYPES[key as keyof typeof MOCKUP_TYPES]
@@ -33,22 +36,54 @@ export const Carousal = ({
     setImages(images)
   }, [mockups])
 
+  const handleDownload = async () => {
+    try {
+      const blob = await downloadImages(images)
+
+      const url = window.URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = DOWNLOAD_ZIP_NAME
+      a.click()
+
+      window.URL.revokeObjectURL(url)
+    } catch (error) {
+      alert(`Failed to download images ${error}`)
+    }
+  }
+
   return (
     <>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="flex items-center gap-2 w-full p-2"
-            onClick={() => setIsOpen(true)}
-          >
-            <IconPicture />
-            <span>View Mockups</span>
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>View Mockups</TooltipContent>
-      </Tooltip>
+      <div className="flex">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="flex items-center gap-2 w-full p-2"
+              onClick={() => setIsOpen(true)}
+            >
+              <IconPicture />
+              <span>View Mockups</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>View Mockups</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="flex items-center gap-2 w-full p-2 button"
+              onClick={handleDownload}
+            >
+              <PinBottomIcon />
+              <span>Download Zip</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Download Zip</TooltipContent>
+        </Tooltip>
+      </div>
       {isOpen && (
         <PreviewCarousel
           images={images}

--- a/lib/redux/apis/files.ts
+++ b/lib/redux/apis/files.ts
@@ -1,0 +1,55 @@
+import { PutBlobResult } from '@vercel/blob'
+import { FileData, Image } from '@/lib/types'
+
+export async function saveFilesApi(
+  files: FileData[],
+  chatId: string,
+  messageId: string,
+  userId: string
+): Promise<Array<PutBlobResult>> {
+  try {
+    const fileBlobs = await Promise.all(
+      files.map(async file => {
+        const response = await fetch(
+          `/api/save-files?chatId=${chatId}&filename=${file.file.name}&userId=${userId}&messageId=${messageId}`,
+          {
+            method: 'POST',
+            body: file.file
+          }
+        )
+
+        if (!response.ok) {
+          throw new Error(`File upload failed: ${file.file.name}`)
+        }
+
+        return response.json()
+      })
+    )
+    return fileBlobs
+  } catch (error) {
+    console.error('Bulk file upload error:', error)
+    throw error
+  }
+}
+
+export const downloadImages = async (images: Image[]): Promise<Blob> => {
+  try {
+    const response = await fetch('/api/images-download', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ images })
+    })
+
+    if (!response.ok) {
+      throw new Error('Network response was not ok')
+    }
+
+    const blob = await response.blob()
+    return blob
+  } catch (error) {
+    console.error('Error downloading images:', error)
+    throw error
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -146,6 +146,7 @@ export type FieldErrors = {
 export interface Image {
   filename: string
   url: string
+  contentType?: string
 }
 
 export type EditableOption = {


### PR DESCRIPTION
## Description

This PR corresponds to the following [Implement-Functionality-to-Allow-Users-to-Download-Generated-Mockups](https://www.notion.so/conradlabshq/Implement-Functionality-to-Allow-Users-to-Download-Generated-Mockups-1c3512441d3c80828440fa9d9e528b36?pvs=4)

### Changes Made
- Add API endpoint to process image downloads and create a ZIP file.
- Frontend integration to trigger ZIP file downloads on button click.
- Add content type in image type to handle image extensions while downloading.

## Screenshots (Optional)

Please refer to the following screenshots

- Before the UI changes
<img width="738" alt="Screenshot 2025-03-28 at 3 28 08 PM" src="https://github.com/user-attachments/assets/b539c72a-cc7d-4e38-94da-b24fa39410a9" />

- After the UI changes
<img width="758" alt="Screenshot 2025-03-28 at 3 27 48 PM" src="https://github.com/user-attachments/assets/22f84b06-bb93-4ed8-b62c-733e0488f335" />
