### PR TITLE
Feat: Allow users to use app without logging in

### DIFF
--- a/app/(chat)/chat/[id]/page.tsx
+++ b/app/(chat)/chat/[id]/page.tsx
@@ -2,7 +2,7 @@ import { notFound, redirect } from 'next/navigation'
 
 import { auth } from '@/auth'
 import { getChat, getMissingKeys } from '@/app/actions'
-import { Chat as UserChatMessage, Session, ChatResponse } from '@/lib/types'
+import { Chat as UserChatMessage, Session } from '@/lib/types'
 import { Error401Response } from '@/app/constants'
 import { Chat } from '@/components/chat'
 import { AI } from '@/app/(chat)/ai'
@@ -16,12 +16,11 @@ export default async function ChatPage({ params }: ChatPageProps) {
   const session = (await auth()) as Session
   const missingKeys = await getMissingKeys()
 
-  if (!session?.user) {
-    redirect(`/login?next=/chat/${params.id}`)
+  const userId = session?.user.id
+  if (!userId) {
+    redirect('/')
   }
-
-  const userId = session.user.id as string
-  let existingChat: ChatResponse = await getChat(params.id, userId)
+  let existingChat = await getChat(params.id, userId)
 
   if (!existingChat || Error401Response.message in existingChat) {
     redirect('/')

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -2,7 +2,6 @@ import { Chat } from '@/components/chat'
 import { auth } from '@/auth'
 import { Session } from '@/lib/types'
 import { getMissingKeys } from '@/app/actions'
-import { redirect } from 'next/navigation'
 import { AI } from '@/app/(chat)/ai'
 
 export const metadata = {

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -13,10 +13,6 @@ export default async function IndexPage() {
   const session = (await auth()) as Session
   const missingKeys = await getMissingKeys()
 
-  if (!session) {
-    redirect('/login')
-  }
-
   return (
     <AI>
       <Chat session={session} missingKeys={missingKeys} />

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -3,6 +3,7 @@ import { auth } from '@/auth'
 import { Session } from '@/lib/types'
 import { getMissingKeys } from '@/app/actions'
 import { AI } from '@/app/(chat)/ai'
+import { createInitialAIState } from '@/lib/ai-tools/utils'
 
 export const metadata = {
   title: 'Conrad Labs AI Chatbot'
@@ -13,7 +14,7 @@ export default async function IndexPage() {
   const missingKeys = await getMissingKeys()
 
   return (
-    <AI>
+    <AI initialAIState={createInitialAIState()}>
       <Chat session={session} missingKeys={missingKeys} />
     </AI>
   )

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -45,6 +45,10 @@ export async function getChats(userId?: string | null) {
 export async function getChat(id: string, userId: string) {
   const session = await auth()
 
+  if (!session) {
+    return
+  }
+
   if (userId !== session?.user?.id) {
     return {
       error: Error401Response.message

--- a/app/api/save-files/route.ts
+++ b/app/api/save-files/route.ts
@@ -34,6 +34,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           message: Error401Response.message
         })
       }
+    } else if (filename && file && chatId) {
+      const blob = await put(`temp/anon/chat:${chatId}/${filename}`, file, {
+        access: BlobAccess.public
+      })
+      return NextResponse.json(blob)
     } else {
       return NextResponse.json({
         status: Error400Response.status,

--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -23,22 +23,18 @@ export async function authenticate(
 ): Promise<Result | undefined> {
   try {
     const email = formData.get('email')
-    const password = formData.get('password')
 
     const parsedCredentials = z
       .object({
-        email: z.string().email(),
-        password: z.string().min(6)
+        email: z.string().email()
       })
       .safeParse({
-        email,
-        password
+        email
       })
 
     if (parsedCredentials.success) {
       await signIn('credentials', {
         email,
-        password,
         redirect: false
       })
 

--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -6,6 +6,7 @@ import { AuthError } from 'next-auth'
 import { z } from 'zod'
 import { kv } from '@vercel/kv'
 import { ErrorMessage, SuccessMessage } from '../constants'
+import { signup } from '../signup/actions'
 
 export async function getUser(email: string) {
   const user = await kv.hgetall<User>(`user:${email}`)
@@ -64,4 +65,21 @@ export async function authenticate(
       }
     }
   }
+}
+
+export async function authenticateOrSignup(
+  prevState: Result | undefined,
+  formData: FormData
+): Promise<Result | undefined> {
+  const email = formData.get('email') as string
+  const user = await getUser(email)
+
+  let result: Result | undefined
+  if (!user) {
+    result = await signup(prevState, formData)
+  } else {
+    result = await authenticate(prevState, formData)
+  }
+
+  return result
 }

--- a/app/signup/actions.ts
+++ b/app/signup/actions.ts
@@ -12,8 +12,6 @@ import { formatError } from '@/lib/utils/format-errors'
 
 export async function createUser(
   email: string,
-  hashedPassword: string,
-  username: string,
   phoneNumber: string,
   salt: string
 ) {
@@ -28,8 +26,6 @@ export async function createUser(
     const user = {
       id: crypto.randomUUID(),
       email,
-      password: hashedPassword,
-      username,
       phoneNumber,
       salt
     }
@@ -53,41 +49,22 @@ export async function signup(
   formData: FormData
 ): Promise<ActionResult | undefined> {
   const email = formData.get('email') as string
-  const password = formData.get('password') as string
-  const username = formData.get('username') as string
   const phoneNumber = formData.get('phoneNumber') as string
 
   const parsedCredentials = SignupSchema.safeParse({
     email,
-    password,
-    username,
     phoneNumber
   })
 
   if (parsedCredentials.success) {
     const salt = crypto.randomUUID()
 
-    const encoder = new TextEncoder()
-    const saltedPassword = encoder.encode(password + salt)
-    const hashedPasswordBuffer = await crypto.subtle.digest(
-      'SHA-256',
-      saltedPassword
-    )
-    const hashedPassword = getStringFromBuffer(hashedPasswordBuffer)
-
     try {
-      const result = await createUser(
-        email,
-        hashedPassword,
-        username,
-        phoneNumber,
-        salt
-      )
+      const result = await createUser(email, phoneNumber, salt)
 
       if (result.resultCode === ResultCode.UserCreated) {
         await signIn('credentials', {
           email,
-          password,
           redirect: false
         })
       }

--- a/auth.ts
+++ b/auth.ts
@@ -15,7 +15,11 @@ export const { auth, signIn, signOut } = NextAuth({
           })
           .safeParse(credentials)
 
-        if (parsedCredentials.success) {
+        if (
+          parsedCredentials &&
+          parsedCredentials.success &&
+          parsedCredentials.data
+        ) {
           const { email } = parsedCredentials.data
           const user = await getUser(email)
 

--- a/auth.ts
+++ b/auth.ts
@@ -2,7 +2,6 @@ import NextAuth from 'next-auth'
 import Credentials from 'next-auth/providers/credentials'
 import { authConfig } from './auth.config'
 import { z } from 'zod'
-import { getStringFromBuffer } from './lib/utils'
 import { getUser } from './app/login/actions'
 
 export const { auth, signIn, signOut } = NextAuth({
@@ -12,30 +11,15 @@ export const { auth, signIn, signOut } = NextAuth({
       async authorize(credentials) {
         const parsedCredentials = z
           .object({
-            email: z.string().email(),
-            password: z.string().min(6)
+            email: z.string().email()
           })
           .safeParse(credentials)
 
         if (parsedCredentials.success) {
-          const { email, password } = parsedCredentials.data
+          const { email } = parsedCredentials.data
           const user = await getUser(email)
 
-          if (!user) return null
-
-          const encoder = new TextEncoder()
-          const saltedPassword = encoder.encode(password + user.salt)
-          const hashedPasswordBuffer = await crypto.subtle.digest(
-            'SHA-256',
-            saltedPassword
-          )
-          const hashedPassword = getStringFromBuffer(hashedPasswordBuffer)
-
-          if (hashedPassword === user.password) {
-            return user
-          } else {
-            return null
-          }
+          if (user) return user
         }
 
         return null

--- a/components/chat-history.tsx
+++ b/components/chat-history.tsx
@@ -1,46 +1,69 @@
-import * as React from 'react'
+'use client'
 
+import * as React from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 
 import { cn } from '@/lib/utils'
 import { SidebarList } from '@/components/sidebar-list'
-import { buttonVariants } from '@/components/ui/button'
+import { Button, buttonVariants } from '@/components/ui/button'
 import { IconPlus } from '@/components/ui/icons'
 
 interface ChatHistoryProps {
   userId?: string
 }
 
-export async function ChatHistory({ userId }: ChatHistoryProps) {
+export function ChatHistory({ userId }: ChatHistoryProps) {
+  const router = useRouter()
+  const showLogin = !userId
+
   return (
-    <div className="flex flex-col h-full">
-      <div className="mb-2 px-2">
-        <Link
-          href="/"
-          className={cn(
-            buttonVariants({ variant: 'outline' }),
-            'h-10 w-full justify-start bg-action-button text-action-button-foreground px-4 shadow-none transition-colors hover:bg-action-button'
-          )}
-        >
-          <IconPlus className="-translate-x-2 stroke-2" />
-          New Chat
-        </Link>
-      </div>
-      <React.Suspense
-        fallback={
-          <div className="flex flex-col flex-1 px-4 space-y-4 overflow-auto">
-            {Array.from({ length: 10 }).map((_, i) => (
-              <div
-                key={i}
-                className="w-full h-6 rounded-md shrink-0 animate-pulse bg-zinc-200 dark:bg-zinc-800"
-              />
-            ))}
-          </div>
-        }
+    <div className="relative h-full">
+      {showLogin && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center backdrop-blur-sm">
+          <Button
+            onClick={() => router.push('/login')}
+            className="bg-background text-foreground"
+          >
+            Log In to View Chat History
+          </Button>
+        </div>
+      )}
+
+      <div
+        className={cn(
+          'flex flex-col h-full',
+          showLogin ? 'pointer-events-none' : ''
+        )}
       >
-        {/* @ts-ignore */}
-        <SidebarList userId={userId} />
-      </React.Suspense>
+        <div className="mb-2 px-2">
+          <Link
+            href="/"
+            className={cn(
+              buttonVariants({ variant: 'outline' }),
+              'h-10 w-full justify-start bg-action-button text-action-button-foreground px-4 shadow-none transition-colors hover:bg-action-button'
+            )}
+          >
+            <IconPlus className="-translate-x-2 stroke-2" />
+            New Chat
+          </Link>
+        </div>
+        <React.Suspense
+          fallback={
+            <div className="flex flex-col flex-1 px-4 space-y-4 overflow-auto">
+              {Array.from({ length: 10 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="w-full h-6 rounded-md shrink-0 animate-pulse bg-zinc-200 dark:bg-zinc-800"
+                />
+              ))}
+            </div>
+          }
+        >
+          {/* @ts-ignore */}
+          <SidebarList userId={userId} />
+        </React.Suspense>
+      </div>
     </div>
   )
 }

--- a/components/chat-list.tsx
+++ b/components/chat-list.tsx
@@ -3,7 +3,6 @@ import { useUIState } from 'ai/rsc'
 
 export function ChatList() {
   const [messages, _] = useUIState()
-  console.log('messages', messages)
 
   return (
     <div className="relative mx-auto max-w-2xl px-4">

--- a/components/chat-list.tsx
+++ b/components/chat-list.tsx
@@ -3,11 +3,12 @@ import { useUIState } from 'ai/rsc'
 
 export function ChatList() {
   const [messages, _] = useUIState()
+  console.log('messages', messages)
 
   return (
     <div className="relative mx-auto max-w-2xl px-4">
-      {messages.map((item: ClientMessage, index: number) => (
-        <div key={index}>{item.display}</div>
+      {messages.map((item: ClientMessage) => (
+        <div key={item.id}>{item.display}</div>
       ))}
     </div>
   )

--- a/components/chat-list.tsx
+++ b/components/chat-list.tsx
@@ -1,44 +1,14 @@
-import { Separator } from '@/components/ui/separator'
-import { ClientMessage, Session } from '@/lib/types'
-import Link from 'next/link'
-import { ExclamationTriangleIcon } from '@radix-ui/react-icons'
+import { ClientMessage } from '@/lib/types'
 import { useUIState } from 'ai/rsc'
 
-export interface ChatList {
-  session?: Session
-  isShared: boolean
-}
-
-export function ChatList({ session, isShared }: ChatList) {
+export function ChatList() {
   const [messages, _] = useUIState()
 
   return (
     <div className="relative mx-auto max-w-2xl px-4">
-      {!isShared && !session ? (
-        <>
-          <div className="group relative mb-4 flex items-start md:-ml-12">
-            <div className="bg-background flex size-[25px] shrink-0 select-none items-center justify-center rounded-md border shadow-sm">
-              <ExclamationTriangleIcon />
-            </div>
-            <div className="ml-4 flex-1 space-y-2 overflow-hidden px-1">
-              <p className="text-muted-foreground leading-normal">
-                Please{' '}
-                <Link href="/login" className="underline">
-                  log in
-                </Link>{' '}
-                or{' '}
-                <Link href="/signup" className="underline">
-                  sign up
-                </Link>{' '}
-                to save and revisit your chat history!
-              </p>
-            </div>
-          </div>
-          <Separator className="my-4" />
-        </>
-      ) : null}
-
-      {messages.map((item: ClientMessage) => item.display)}
+      {messages.map((item: ClientMessage, index: number) => (
+        <div key={index}>{item.display}</div>
+      ))}
     </div>
   )
 }

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -24,59 +24,6 @@ export function ChatPanel({
       />
 
       <div className="mx-auto sm:max-w-2xl sm:px-4">
-        <div className="mb-4 grid grid-cols-2 gap-2 px-4 sm:px-0">
-          {/* {messages.length === 0 &&
-            exampleMessages.map((example, index) => (
-              <div
-                key={example.heading}
-                className={`cursor-pointer rounded-lg border bg-white p-4 hover:bg-zinc-50 dark:bg-zinc-950 dark:hover:bg-zinc-900 ${
-                  index > 1 && 'hidden md:block'
-                }`}
-                onClick={async () => {
-                  // setMessages(currentMessages => [
-                  //   ...currentMessages,
-                  //   {
-                  //     id: nanoid(),
-                  //     display: <UserMessage>{example.message}</UserMessage>
-                  //   }
-                  // ])
-
-                  // const responseMessage = await submitUserMessage(
-                  //   example.message
-                  // )
-
-                  // setMessages(currentMessages => [
-                  //   ...currentMessages,
-                  //   responseMessage
-                  // ])
-                }}
-              >
-                <div className="text-sm font-semibold">{example.heading}</div>
-                <div className="text-sm text-zinc-600">
-                  {example.subheading}
-                </div>
-              </div>
-            ))} */}
-        </div>
-
-        {/* {messages?.length >= 2 ? (
-          <div className="flex h-12 items-center justify-center">
-            <div className="flex space-x-2">
-              {id && title ? (
-                <>
-                  <Button
-                    variant="outline"
-                    onClick={() => setShareDialogOpen(true)}
-                  >
-                    <IconShare className="mr-2" />
-                    Share
-                  </Button>
-                </>
-              ) : null}
-            </div>
-          </div>
-        ) : null} */}
-
         <div className="space-y-4 border-t bg-background px-4 py-2 shadow-lg sm:rounded-t-xl sm:border md:py-4">
           <PromptForm session={session} />
           <FooterText className="hidden sm:block" />

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -12,6 +12,7 @@ import { usePathname } from 'next/navigation'
 import { useScrollAnchor } from '@/lib/hooks/use-scroll-anchor'
 import { toast } from 'sonner'
 import { CHAT } from '@/app/constants'
+import { nanoid } from 'nanoid'
 
 export interface ChatProps extends React.ComponentProps<'div'> {
   className?: string
@@ -27,7 +28,7 @@ export function Chat({ className, session, missingKeys }: ChatProps) {
     if (!path.includes(CHAT)) {
       window.history.replaceState({}, '', aiState.path)
     }
-  }, [aiState.id, path, session?.user])
+  }, [aiState.id, path])
 
   useEffect(() => {
     setNewChatId(aiState.id)

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -24,10 +24,8 @@ export function Chat({ className, session, missingKeys }: ChatProps) {
   const [aiState, _setAIState] = useAIState()
   const [_, setNewChatId] = useLocalStorage('newChatId', aiState.id)
   useEffect(() => {
-    if (session?.user) {
-      if (!path.includes(CHAT)) {
-        window.history.replaceState({}, '', aiState.path)
-      }
+    if (!path.includes(CHAT)) {
+      window.history.replaceState({}, '', aiState.path)
     }
   }, [aiState.id, path, session?.user])
 
@@ -53,11 +51,7 @@ export function Chat({ className, session, missingKeys }: ChatProps) {
         className={cn('pb-[200px] pt-4 md:pt-10', className)}
         ref={messagesRef}
       >
-        {aiState.messages.length ? (
-          <ChatList isShared={false} session={session} />
-        ) : (
-          <EmptyScreen />
-        )}
+        {aiState.messages.length ? <ChatList /> : <EmptyScreen />}
         <div className="w-full h-px" ref={visibilityRef} />
       </div>
       <ChatPanel

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,15 +1,8 @@
 import * as React from 'react'
 import Link from 'next/link'
 
-import { cn } from '@/lib/utils'
 import { auth } from '@/auth'
-import { Button, buttonVariants } from '@/components/ui/button'
-import {
-  IconGitHub,
-  IconNextChat,
-  IconSeparator,
-  IconVercel
-} from '@/components/ui/icons'
+import { Button } from '@/components/ui/button'
 import { UserMenu } from '@/components/user-menu'
 import { SidebarMobile } from './sidebar-mobile'
 import { SidebarToggle } from './sidebar-toggle'
@@ -20,32 +13,18 @@ async function UserOrLogin() {
   const session = (await auth()) as Session
   return (
     <>
-      {session?.user ? (
-        <>
-          <Link href="/new" rel="nofollow">
-            <img src="/logo.png" className="invert dark:invert-0 h-6 w-auto" />
-          </Link>
+      <Link href="/new" rel="nofollow">
+        <img src="/logo.png" className="invert dark:invert-0 h-6 w-auto" />
+      </Link>
 
-          <div className="ml-2">
-            <SidebarMobile>
-              <ChatHistory userId={session.user.id} />
-            </SidebarMobile>
-            <SidebarToggle />
-          </div>
-        </>
-      ) : (
-        <Link href="/new" rel="nofollow">
-          <img src="/logo.png" className="invert dark:invert-0 h-6 w-auto" />
-        </Link>
-      )}
+      <div className="ml-2">
+        <SidebarMobile>
+          <ChatHistory userId={session?.user.id} />
+        </SidebarMobile>
+        <SidebarToggle />
+      </div>
       <div className="flex items-center">
-        {session?.user ? (
-          <UserMenu user={session.user} />
-        ) : (
-          <Button variant="link" asChild className="-ml-2">
-            <Link href="/login">Login</Link>
-          </Button>
-        )}
+        <UserMenu user={session?.user} />
       </div>
     </>
   )

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -57,25 +57,6 @@ export default function LoginForm() {
               />
             </div>
           </div>
-          <div className="mt-4">
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-zinc-400"
-              htmlFor="password"
-            >
-              Password
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border bg-zinc-50 px-2 py-[9px] text-sm outline-none placeholder:text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950"
-                id="password"
-                type="password"
-                name="password"
-                placeholder="Enter password"
-                required
-                minLength={6}
-              />
-            </div>
-          </div>
         </div>
         <LoginButton />
       </div>

--- a/components/sidebar-desktop.tsx
+++ b/components/sidebar-desktop.tsx
@@ -9,7 +9,7 @@ export async function SidebarDesktop() {
   return (
     <Sidebar className="peer absolute inset-y-0 z-30 hidden -translate-x-full border-r bg-muted duration-300 ease-in-out data-[state=open]:translate-x-0 lg:flex lg:w-[250px] xl:w-[300px]">
       {/* @ts-ignore */}
-      <ChatHistory userId={session?.user.id} />
+      <ChatHistory userId={session?.user?.id} />
     </Sidebar>
   )
 }

--- a/components/sidebar-desktop.tsx
+++ b/components/sidebar-desktop.tsx
@@ -6,14 +6,10 @@ import { ChatHistory } from '@/components/chat-history'
 export async function SidebarDesktop() {
   const session = await auth()
 
-  if (!session?.user?.id) {
-    return null
-  }
-
   return (
     <Sidebar className="peer absolute inset-y-0 z-30 hidden -translate-x-full border-r bg-muted duration-300 ease-in-out data-[state=open]:translate-x-0 lg:flex lg:w-[250px] xl:w-[300px]">
       {/* @ts-ignore */}
-      <ChatHistory userId={session.user.id} />
+      <ChatHistory userId={session?.user.id} />
     </Sidebar>
   )
 }

--- a/components/sidebar-mobile.tsx
+++ b/components/sidebar-mobile.tsx
@@ -1,6 +1,11 @@
 'use client'
 
-import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet'
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger
+} from '@/components/ui/sheet'
 
 import { Sidebar } from '@/components/sidebar'
 import { Button } from '@/components/ui/button'
@@ -20,6 +25,7 @@ export function SidebarMobile({ children }: SidebarMobileProps) {
           <span className="sr-only">Toggle Sidebar</span>
         </Button>
       </SheetTrigger>
+      <SheetTitle className="hidden">Mobile Sidebar</SheetTitle>
       <SheetContent
         side="left"
         className="inset-y-0 flex h-auto w-[300px] flex-col p-0"

--- a/components/signup-form.tsx
+++ b/components/signup-form.tsx
@@ -41,15 +41,6 @@ export default function SignupForm() {
         <h1 className="mb-3 text-2xl font-bold">Sign up for an account!</h1>
         <div className="w-full">
           <InputField
-            label="Username"
-            id="username"
-            name="username"
-            placeholder="Enter your username"
-            error={result?.errors?.fieldErrors?.username}
-            type="text"
-            required
-          />
-          <InputField
             label="Email"
             id="email"
             name="email"
@@ -67,17 +58,6 @@ export default function SignupForm() {
             error={result?.errors?.fieldErrors?.phoneNumber}
             type="text"
             containerClassName="mt-2"
-            required
-          />
-          <InputField
-            label="Password"
-            id="password"
-            name="password"
-            placeholder="Enter password"
-            error={result?.errors?.fieldErrors?.password}
-            type="password"
-            containerClassName="mt-2"
-            minLength={6}
             required
           />
         </div>

--- a/components/stocks/message.tsx
+++ b/components/stocks/message.tsx
@@ -23,11 +23,15 @@ export function UserMessage({ content }: { content: UserContent }) {
     } catch (e) {}
   }
   const isStringContent = typeof content === 'string'
+  const isNumberContent = typeof content === 'number'
   const isImageContent = Array.isArray(content)
   const isColorContent = !isStringContent && !isImageContent
   const renderContent = () => {
     if (isStringContent) {
       return <span>{content as string}</span>
+    } else if (isNumberContent) {
+      const numberContent = content.toString()
+      return <span>{numberContent as string}</span>
     } else if (isImageContent) {
       return (
         <div className="flex flex-wrap gap-4 mx-4 mb-2">

--- a/components/user-details-form.tsx
+++ b/components/user-details-form.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { authenticateOrSignup } from '@/app/login/actions'
+import { useRouter } from 'next/navigation'
+import { saveChat } from '@/app/actions'
+import { useAIState, useUIState } from 'ai/rsc'
+
+export interface UserDetailsFormProps {
+  messageId: string
+}
+
+export function UserDetailsForm({ messageId }: UserDetailsFormProps) {
+  const router = useRouter()
+  const [messages, _setMessages] = useUIState()
+  const [aiState, _setAIState] = useAIState()
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+    const result = await authenticateOrSignup(undefined, formData)
+    if (result?.type === 'success') {
+      await saveChat(aiState)
+      router.refresh()
+    } else {
+      console.error(result?.resultCode)
+    }
+  }
+
+  return (
+    <form
+      aria-disabled={messageId !== messages.at(-1)?.id || aiState.loading}
+      className="space-y-4 px-1"
+      onSubmit={handleSubmit}
+    >
+      <div>
+        <label
+          className="mb-3 block text-xs font-medium text-zinc-400"
+          htmlFor="email"
+        >
+          Email
+        </label>
+        <div className="relative">
+          <input
+            className="peer block w-full rounded-md border bg-zinc-50 px-2 py-[9px] text-sm outline-none placeholder:text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950"
+            id="email"
+            type="email"
+            name="email"
+            placeholder="Enter your email address"
+            required
+          />
+        </div>
+      </div>
+      <div>
+        <label
+          className="mb-3 mt-5 block text-xs font-medium text-zinc-400"
+          htmlFor="phoneNumber"
+        >
+          Phone Number
+        </label>
+        <div className="relative">
+          <input
+            className="peer block w-full rounded-md border bg-zinc-50 px-2 py-[9px] text-sm outline-none placeholder:text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950"
+            id="phoneNumber"
+            type="text"
+            name="phoneNumber"
+            placeholder="Enter your phone number"
+            required
+          />
+        </div>
+      </div>
+      <button
+        type="submit"
+        disabled={messageId !== messages.at(-1)?.id || aiState.loading}
+        className="my-4 h-10 w-full rounded-md bg-action-button p-2 text-sm font-semibold"
+      >
+        Submit Details
+      </button>
+    </form>
+  )
+}

--- a/components/user-details-form.tsx
+++ b/components/user-details-form.tsx
@@ -2,79 +2,114 @@
 
 import { authenticateOrSignup } from '@/app/login/actions'
 import { useRouter } from 'next/navigation'
+import { useAIState, useUIState, useActions } from 'ai/rsc'
+import { toast } from 'sonner'
+import { getMessageFromCode } from '@/lib/utils'
 import { saveChat } from '@/app/actions'
-import { useAIState, useUIState } from 'ai/rsc'
 
 export interface UserDetailsFormProps {
   messageId: string
+  action: string
+  email?: string
+  phoneNumber?: string
+  disabled: boolean
 }
 
-export function UserDetailsForm({ messageId }: UserDetailsFormProps) {
+export function UserDetailsForm({
+  messageId,
+  action,
+  email,
+  phoneNumber,
+  disabled
+}: UserDetailsFormProps) {
   const router = useRouter()
   const [messages, _setMessages] = useUIState()
   const [aiState, _setAIState] = useAIState()
+  const { submitUserMessage } = useActions()
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     const formData = new FormData(e.currentTarget)
     const result = await authenticateOrSignup(undefined, formData)
     if (result?.type === 'success') {
+      const jsonResult = Object.fromEntries(formData.entries())
+      await submitUserMessage(JSON.stringify(jsonResult))
+      _setMessages((currentMessages: any) => currentMessages.slice(0, -1))
       await saveChat(aiState)
+      toast.success(getMessageFromCode(result.resultCode))
       router.refresh()
     } else {
       console.error(result?.resultCode)
+      const error = result?.resultCode
+        ? getMessageFromCode(result.resultCode)
+        : 'An unexpected error occurred, please try again later!'
+      toast.error(error)
     }
   }
 
   return (
-    <form
-      aria-disabled={messageId !== messages.at(-1)?.id || aiState.loading}
-      className="space-y-4 px-1"
-      onSubmit={handleSubmit}
-    >
-      <div>
-        <label
-          className="mb-3 block text-xs font-medium text-zinc-400"
-          htmlFor="email"
-        >
-          Email
-        </label>
-        <div className="relative">
-          <input
-            className="peer block w-full rounded-md border bg-zinc-50 px-2 py-[9px] text-sm outline-none placeholder:text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950"
-            id="email"
-            type="email"
-            name="email"
-            placeholder="Enter your email address"
-            required
-          />
+    <div className="prose break-words dark:prose-invert prose-p:leading-relaxed prose-pre:p-0">
+      {disabled ? (
+        <div>
+          <div>Your order has been placed with the following details:</div>
+          <ul className="space-y-2">
+            <li>Email: {email}</li>
+            <li>Phone number: {phoneNumber}</li>
+          </ul>
+          <div>Thank you for choosing Custom Canopy!</div>
         </div>
-      </div>
-      <div>
-        <label
-          className="mb-3 mt-5 block text-xs font-medium text-zinc-400"
-          htmlFor="phoneNumber"
+      ) : (
+        <form
+          aria-disabled={messageId !== messages.at(-1)?.id || aiState.loading}
+          className="space-y-4 px-1"
+          onSubmit={handleSubmit}
         >
-          Phone Number
-        </label>
-        <div className="relative">
-          <input
-            className="peer block w-full rounded-md border bg-zinc-50 px-2 py-[9px] text-sm outline-none placeholder:text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950"
-            id="phoneNumber"
-            type="text"
-            name="phoneNumber"
-            placeholder="Enter your phone number"
-            required
-          />
-        </div>
-      </div>
-      <button
-        type="submit"
-        disabled={messageId !== messages.at(-1)?.id || aiState.loading}
-        className="my-4 h-10 w-full rounded-md bg-action-button p-2 text-sm font-semibold"
-      >
-        Submit Details
-      </button>
-    </form>
+          <div>Please provide the following information:</div>
+          <div>
+            <label
+              className="mb-3 block text-xs font-medium text-zinc-400"
+              htmlFor="email"
+            >
+              Email
+            </label>
+            <div className="relative">
+              <input
+                className="peer block w-full rounded-md border bg-zinc-50 px-2 py-[9px] text-sm outline-none placeholder:text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950"
+                id="email"
+                type="email"
+                name="email"
+                placeholder="Enter your email address"
+                required
+              />
+            </div>
+          </div>
+          <div>
+            <label
+              className="mb-3 mt-5 block text-xs font-medium text-zinc-400"
+              htmlFor="phoneNumber"
+            >
+              Phone Number
+            </label>
+            <div className="relative">
+              <input
+                className="peer block w-full rounded-md border bg-zinc-50 px-2 py-[9px] text-sm outline-none placeholder:text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950"
+                id="phoneNumber"
+                type="text"
+                name="phoneNumber"
+                placeholder="Enter your phone number"
+                required
+              />
+            </div>
+          </div>
+          <button
+            type="submit"
+            disabled={messageId !== messages.at(-1)?.id || aiState.loading}
+            className="my-4 h-10 w-full rounded-md bg-action-button p-2 text-sm font-semibold"
+          >
+            {action}
+          </button>
+        </form>
+      )}
+    </div>
   )
 }

--- a/components/user-details-form.tsx
+++ b/components/user-details-form.tsx
@@ -9,19 +9,9 @@ import { saveChat } from '@/app/actions'
 
 export interface UserDetailsFormProps {
   messageId: string
-  action: string
-  email?: string
-  phoneNumber?: string
-  disabled: boolean
 }
 
-export function UserDetailsForm({
-  messageId,
-  action,
-  email,
-  phoneNumber,
-  disabled
-}: UserDetailsFormProps) {
+export function UserDetailsForm({ messageId }: UserDetailsFormProps) {
   const router = useRouter()
   const [messages, _setMessages] = useUIState()
   const [aiState, _setAIState] = useAIState()
@@ -34,7 +24,6 @@ export function UserDetailsForm({
     if (result?.type === 'success') {
       const jsonResult = Object.fromEntries(formData.entries())
       await submitUserMessage(JSON.stringify(jsonResult))
-      _setMessages((currentMessages: any) => currentMessages.slice(0, -1))
       await saveChat(aiState)
       toast.success(getMessageFromCode(result.resultCode))
       router.refresh()
@@ -48,68 +37,56 @@ export function UserDetailsForm({
   }
 
   return (
-    <div className="prose break-words dark:prose-invert prose-p:leading-relaxed prose-pre:p-0 -mt-4 mx-2">
-      {disabled ? (
+    <div className="prose break-words dark:prose-invert prose-p:leading-relaxed prose-pre:p-0">
+      <form
+        aria-disabled={messageId !== messages.at(-1)?.id || aiState.loading}
+        className="space-y-4 px-1"
+        onSubmit={handleSubmit}
+      >
         <div>
-          <div>Your order has been placed with the following details:</div>
-          <ul className="space-y-2">
-            <li>Email: {email}</li>
-            <li>Phone number: {phoneNumber}</li>
-          </ul>
-          <div>Thank you for choosing Custom Canopy!</div>
-        </div>
-      ) : (
-        <form
-          aria-disabled={messageId !== messages.at(-1)?.id || aiState.loading}
-          className="space-y-4 px-1"
-          onSubmit={handleSubmit}
-        >
-          <div>Please provide the following information:</div>
-          <div>
-            <label
-              className="mb-3 block text-xs font-medium text-zinc-400"
-              htmlFor="email"
-            >
-              Email
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border bg-zinc-50 px-2 py-[9px] text-sm outline-none placeholder:text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950"
-                id="email"
-                type="email"
-                name="email"
-                placeholder="Enter your email address"
-                required
-              />
-            </div>
-          </div>
-          <div>
-            <label
-              className="mb-3 mt-5 block text-xs font-medium text-zinc-400"
-              htmlFor="phoneNumber"
-            >
-              Phone Number
-            </label>
-            <div className="relative">
-              <input
-                className="peer block w-full rounded-md border bg-zinc-50 px-2 py-[9px] text-sm outline-none placeholder:text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950"
-                id="phoneNumber"
-                type="text"
-                name="phoneNumber"
-                placeholder="Enter your phone number"
-                required
-              />
-            </div>
-          </div>
-          <button
-            type="submit"
-            disabled={messageId !== messages.at(-1)?.id || aiState.loading}
-            className="my-4 h-10 w-full rounded-md bg-action-button p-2 text-sm font-semibold"
+          <label
+            className="mb-3 block text-xs font-medium text-zinc-400"
+            htmlFor="email"
           >
-            {action}
-          </button>
-        </form>
-      )}
+            Email
+          </label>
+          <div className="relative">
+            <input
+              className="peer block w-full rounded-md border bg-zinc-50 px-2 py-[9px] text-sm outline-none placeholder:text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950"
+              id="email"
+              type="email"
+              name="email"
+              placeholder="Enter your email address"
+              required
+            />
+          </div>
+        </div>
+        <div>
+          <label
+            className="mb-3 mt-5 block text-xs font-medium text-zinc-400"
+            htmlFor="phoneNumber"
+          >
+            Phone Number
+          </label>
+          <div className="relative">
+            <input
+              className="peer block w-full rounded-md border bg-zinc-50 px-2 py-[9px] text-sm outline-none placeholder:text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950"
+              id="phoneNumber"
+              type="text"
+              name="phoneNumber"
+              placeholder="Enter your phone number"
+              required
+            />
+          </div>
+        </div>
+        <button
+          type="submit"
+          disabled={messageId !== messages.at(-1)?.id || aiState.loading}
+          className="my-4 h-10 w-full rounded-md bg-action-button p-2 text-sm font-semibold"
+        >
+          Submit Details
+        </button>
+      </form>
     </div>
   )
 }

--- a/components/user-details-form.tsx
+++ b/components/user-details-form.tsx
@@ -48,7 +48,7 @@ export function UserDetailsForm({
   }
 
   return (
-    <div className="prose break-words dark:prose-invert prose-p:leading-relaxed prose-pre:p-0">
+    <div className="prose break-words dark:prose-invert prose-p:leading-relaxed prose-pre:p-0 -mt-4 mx-2">
       {disabled ? (
         <div>
           <div>Your order has been placed with the following details:</div>

--- a/components/user-menu.tsx
+++ b/components/user-menu.tsx
@@ -9,9 +9,10 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { signOut } from '@/auth'
+import Link from 'next/link'
 
 export interface UserMenuProps {
-  user: Session['user']
+  user?: Session['user']
 }
 
 function getUserInitials(name: string) {
@@ -21,33 +22,59 @@ function getUserInitials(name: string) {
 
 export function UserMenu({ user }: UserMenuProps) {
   return (
-    <div className="flex items-center justify-between">
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="ghost" className="pl-0">
-            <div className="flex size-7 shrink-0 select-none items-center justify-center rounded-full bg-muted/50 text-xs font-medium uppercase text-muted-foreground">
-              {getUserInitials(user.email)}
-            </div>
-            <span className="ml-2 hidden md:block">{user.email}</span>
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent sideOffset={8} align="start" className="w-fit">
-          <DropdownMenuItem className="flex-col items-start">
-            <div className="text-xs text-zinc-500">{user.email}</div>
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <form
-            action={async () => {
-              'use server'
-              await signOut()
-            }}
-          >
-            <button className=" relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none transition-colors hover:bg-red-500 hover:text-white focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">
-              Sign Out
-            </button>
-          </form>
-        </DropdownMenuContent>
-      </DropdownMenu>
+    <div className="flex items-center justify-between ml-2">
+      {user ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" className="pl-0">
+              <div className="flex size-7 shrink-0 select-none items-center justify-center rounded-full bg-muted/50 text-xs font-medium uppercase text-muted-foreground">
+                {getUserInitials(user.email)}
+              </div>
+              <span className="ml-2 hidden md:block">{user.email}</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent sideOffset={8} align="start" className="w-fit">
+            <DropdownMenuItem className="flex-col items-start">
+              <div className="text-xs text-zinc-500">{user.email}</div>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <form
+              action={async () => {
+                'use server'
+                await signOut()
+              }}
+            >
+              <button className=" relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none transition-colors hover:bg-red-500 hover:text-white focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">
+                Sign Out
+              </button>
+            </form>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" className="pl-0">
+              <div className="flex size-7 shrink-0 select-none items-center justify-center rounded-full bg-muted/50 text-xs font-medium uppercase text-muted-foreground">
+                AN
+              </div>
+              <span className="ml-2 hidden md:block">Anonymous</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent sideOffset={8} align="start" className="w-fit">
+            <DropdownMenuItem className="flex-col items-start">
+              <Button variant="link" className="-ml-2">
+                <Link href="/login">Login</Link>
+              </Button>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem className="flex-col items-start">
+              <Button variant="link" className="-ml-2">
+                <Link href="/signup">Sign up</Link>
+              </Button>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
     </div>
   )
 }

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -49,9 +49,8 @@ export const PROMPT_INSTRUCTIONS = `
       3. If the user selects "No," ask them which details they want to change, make the updates.
 
       ** Place order Workflow:** (If the user clicks on "Place order" button)
-       - Prompt the user to provide their email and phone number one by one:
-        - {content}: ["Please provide your email address for contact purposes:", "Next, please provide your phone number."]
-       - After getting the email and phone number, finalize the order and complete the conversation.
+       - EXPLICITLY CALL the placeFinalOrder tool and obtain the email and phone number from the user.
+       - After the tool call is successful, thank the user for placing their order and complete the conversation.
        - DO NOT generate mockups at this step.
 
       **Add-ons Workflow:**  

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -54,10 +54,7 @@ export const PROMPT_INSTRUCTIONS = `
         2. When email and phone number are provided, EXPLICITLY CALL the showUserDetails tool with the following parameters:
           - {email}: {email}
           - {phoneNumber}: {phoneNumber}
-          - {content}:
-            - "Your order has been placed with the following details. Thank you for choosing Custom Canopy!
-               - Email: {email}
-               - Phone number: {phoneNumber}"
+          - {content}: "Your order has been placed with the following details:\n\n - Email: {email}\n - Phone number: {phoneNumber}\n\n Thank you for choosing Custom Canopy!"
         - DO NOT generate mockups at this step.
 
 

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -49,9 +49,9 @@ export const PROMPT_INSTRUCTIONS = `
       3. If the user selects "No," ask them which details they want to change, make the updates.
 
       ** Place order Workflow:** (If the user clicks on "Place order" button)
-       - EXPLICITLY CALL the placeFinalOrder tool and obtain the email and phone number from the user.
-       - After the tool call is successful, thank the user for placing their order and complete the conversation.
-       - DO NOT generate mockups at this step.
+        - {action}: "Submit Details"
+        - EXPLICITLY CALL the placeFinalOrder tool with {content} as the empty string
+        - DO NOT generate mockups at this step.
 
       **Add-ons Workflow:**  
     - An Add-on is selected if the selected property of that add-on in the Add-ons options array is true.

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -49,9 +49,17 @@ export const PROMPT_INSTRUCTIONS = `
       3. If the user selects "No," ask them which details they want to change, make the updates.
 
       ** Place order Workflow:** (If the user clicks on "Place order" button)
-        - {action}: "Submit Details"
-        - EXPLICITLY CALL the placeFinalOrder tool with {content} as the empty string
+        1. If the "Place Order" option is selected, EXPLICITLY CALL the placeFinalOrder tool with the following parameters:
+          - {content}: "Please provide the following information:"
+        2. When email and phone number are provided, EXPLICITLY CALL the showUserDetails tool with the following parameters:
+          - {email}: {email}
+          - {phoneNumber}: {phoneNumber}
+          - {content}:
+            - "Your order has been placed with the following details. Thank you for choosing Custom Canopy!
+               - Email: {email}
+               - Phone number: {phoneNumber}"
         - DO NOT generate mockups at this step.
+
 
       **Add-ons Workflow:**  
     - An Add-on is selected if the selected property of that add-on in the Add-ons options array is true.
@@ -153,7 +161,8 @@ export const TOOL_FUNCTIONS = {
   RENDER_COLOR_LABEL_PICKER_SET: 'renderColorLabelPickerSet',
   RENDER_REGION_MANAGER: 'renderRegionManager',
   GENERATE_CANOPY_MOCKUPS: 'generateCanopyMockups',
-  PLACE_FINAL_ORDER: 'placeFinalOrder'
+  PLACE_FINAL_ORDER: 'placeFinalOrder',
+  SHOW_USER_DETAILS: 'showUserDetails'
 }
 
 export const INITIAL_CHAT_MESSAGE =

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -153,7 +153,8 @@ export const TOOL_FUNCTIONS = {
   RENDER_TEXT_INPUT_GROUP: 'renderTextInputGroup',
   RENDER_COLOR_LABEL_PICKER_SET: 'renderColorLabelPickerSet',
   RENDER_REGION_MANAGER: 'renderRegionManager',
-  GENERATE_CANOPY_MOCKUPS: 'generateCanopyMockups'
+  GENERATE_CANOPY_MOCKUPS: 'generateCanopyMockups',
+  PLACE_FINAL_ORDER: 'placeFinalOrder'
 }
 
 export const INITIAL_CHAT_MESSAGE =

--- a/lib/ai-tools/schemas.ts
+++ b/lib/ai-tools/schemas.ts
@@ -174,3 +174,11 @@ export const CustomCanopyToolSchema = z.object({
     .describe('Details of the tent to be generated')
     .required()
 })
+
+export const PlaceFinalOrderSchema = z.object({
+  content: z
+    .string()
+    .describe(
+      'Message to display when asking for user details before placing final order'
+    )
+})

--- a/lib/ai-tools/schemas.ts
+++ b/lib/ai-tools/schemas.ts
@@ -180,8 +180,13 @@ export const PlaceFinalOrderSchema = z.object({
     .string()
     .describe(
       'Message to display when asking for user details before placing final order'
-    ),
-  action: z.string().describe('Action to be performed by the form'),
-  email: z.string().describe('Email of the user'),
-  phoneNumber: z.string().describe('Phone number of the user')
+    )
+})
+
+export const ShowUserDetailsSchema = z.object({
+  content: z
+    .string()
+    .describe(
+      'Message to display when asking for user details before placing final order'
+    )
 })

--- a/lib/ai-tools/schemas.ts
+++ b/lib/ai-tools/schemas.ts
@@ -180,5 +180,8 @@ export const PlaceFinalOrderSchema = z.object({
     .string()
     .describe(
       'Message to display when asking for user details before placing final order'
-    )
+    ),
+  action: z.string().describe('Action to be performed by the form'),
+  email: z.string().describe('Email of the user'),
+  phoneNumber: z.string().describe('Phone number of the user')
 })

--- a/lib/ai-tools/tool-functions.tsx
+++ b/lib/ai-tools/tool-functions.tsx
@@ -23,6 +23,7 @@ import ChatActionMultiSelector from '@/components/chat-action-multi-selector'
 import RegionsColorsManager from '@/components/regions_colors_manager'
 import { ColorLabelPickerSet } from '@/components/color-label-picker-set'
 import { UserDetailsForm } from '@/components/user-details-form'
+import { auth } from '@/auth'
 
 function modifyToolAIState(history: any, content: ToolContent) {
   modifyAIState(history, {
@@ -236,20 +237,42 @@ export function placeFinalOrder(history: any, messageId: string) {
       'Handles the final order placement logic including auth and chat saving',
     parameters: PlaceFinalOrderSchema,
     generate: async function ({
-      content
+      content,
+      action,
+      email,
+      phoneNumber
     }: z.infer<typeof PlaceFinalOrderSchema>) {
+      const session = await auth()
       modifyToolAIState(history, [
         {
           toolCallId: messageId,
           toolName: TOOL_FUNCTIONS.PLACE_FINAL_ORDER,
           result: {
-            message: content
+            message: content,
+            props: { action, email, phoneNumber }
           }
         }
       ] as ToolContent)
+      let disabled = false
+      if (session) {
+        disabled = true
+      }
       return (
-        <BotMessage key={messageId} content={content}>
-          <UserDetailsForm messageId={messageId} />
+        <BotMessage
+          key={messageId}
+          content={
+            disabled
+              ? 'Your order has been placed with the following information:'
+              : content
+          }
+        >
+          <UserDetailsForm
+            messageId={messageId}
+            action={action}
+            email={email}
+            phoneNumber={phoneNumber}
+            disabled={disabled}
+          />
         </BotMessage>
       )
     }

--- a/lib/ai-tools/tool-functions.tsx
+++ b/lib/ai-tools/tool-functions.tsx
@@ -8,7 +8,8 @@ import {
   ChatTextInputGroupSchema,
   RegionsColorsManagerSchema,
   ColorLabelPickerSetSchema,
-  PlaceFinalOrderSchema
+  PlaceFinalOrderSchema,
+  ShowUserDetailsSchema
 } from './schemas'
 import { Carousal } from '@/components/carousel'
 import { BotCard, BotMessage } from '@/components/stocks/message'
@@ -23,7 +24,6 @@ import ChatActionMultiSelector from '@/components/chat-action-multi-selector'
 import RegionsColorsManager from '@/components/regions_colors_manager'
 import { ColorLabelPickerSet } from '@/components/color-label-picker-set'
 import { UserDetailsForm } from '@/components/user-details-form'
-import { auth } from '@/auth'
 
 function modifyToolAIState(history: any, content: ToolContent) {
   modifyAIState(history, {
@@ -237,44 +237,43 @@ export function placeFinalOrder(history: any, messageId: string) {
       'Handles the final order placement logic including auth and chat saving',
     parameters: PlaceFinalOrderSchema,
     generate: async function ({
-      content,
-      action,
-      email,
-      phoneNumber
+      content
     }: z.infer<typeof PlaceFinalOrderSchema>) {
-      const session = await auth()
       modifyToolAIState(history, [
         {
           toolCallId: messageId,
           toolName: TOOL_FUNCTIONS.PLACE_FINAL_ORDER,
           result: {
-            message: content,
-            props: { action, email, phoneNumber }
+            message: content
           }
         }
       ] as ToolContent)
-      let disabled = false
-      if (session) {
-        disabled = true
-      }
       return (
-        <BotMessage
-          key={messageId}
-          content={
-            disabled
-              ? 'Your order has been placed with the following information:'
-              : content
-          }
-        >
-          <UserDetailsForm
-            messageId={messageId}
-            action={action}
-            email={email}
-            phoneNumber={phoneNumber}
-            disabled={disabled}
-          />
+        <BotMessage key={messageId} content={content}>
+          <UserDetailsForm messageId={messageId} />
         </BotMessage>
       )
+    }
+  }
+}
+
+export function showUserDetails(history: any, messageId: string) {
+  return {
+    description: "Shows the user's order details",
+    parameters: ShowUserDetailsSchema,
+    generate: async function ({
+      content
+    }: z.infer<typeof ShowUserDetailsSchema>) {
+      modifyToolAIState(history, [
+        {
+          toolCallId: messageId,
+          toolName: TOOL_FUNCTIONS.SHOW_USER_DETAILS,
+          result: {
+            message: content
+          }
+        }
+      ] as ToolContent)
+      return <BotMessage key={messageId} content={content} />
     }
   }
 }
@@ -287,6 +286,7 @@ export const getToolFunctions = (history: any, messageId: string) => {
     renderRegionManager: renderRegionManager(history, messageId),
     renderTextInputGroup: renderTextInputGroup(history, messageId),
     generateCanopyMockups: generateCanopyMockups(history, messageId),
-    placeFinalOrder: placeFinalOrder(history, messageId)
+    placeFinalOrder: placeFinalOrder(history, messageId),
+    showUserDetails: showUserDetails(history, messageId)
   }
 }

--- a/lib/ai-tools/tool-functions.tsx
+++ b/lib/ai-tools/tool-functions.tsx
@@ -7,7 +7,8 @@ import {
   CustomCanopyToolSchema,
   ChatTextInputGroupSchema,
   RegionsColorsManagerSchema,
-  ColorLabelPickerSetSchema
+  ColorLabelPickerSetSchema,
+  PlaceFinalOrderSchema
 } from './schemas'
 import { Carousal } from '@/components/carousel'
 import { BotCard, BotMessage } from '@/components/stocks/message'
@@ -21,6 +22,7 @@ import { ChatTextInputGroup } from '@/components/chat-text-input-group'
 import ChatActionMultiSelector from '@/components/chat-action-multi-selector'
 import RegionsColorsManager from '@/components/regions_colors_manager'
 import { ColorLabelPickerSet } from '@/components/color-label-picker-set'
+import { UserDetailsForm } from '@/components/user-details-form'
 
 function modifyToolAIState(history: any, content: ToolContent) {
   modifyAIState(history, {
@@ -169,6 +171,7 @@ export function renderRegionManager(history: any, messageId: string) {
     }
   }
 }
+
 export function generateCanopyMockups(history: any, messageId: string) {
   return {
     description: 'Generates the images for canopy tents based on user details',
@@ -227,6 +230,32 @@ export function generateCanopyMockups(history: any, messageId: string) {
   }
 }
 
+export function placeFinalOrder(history: any, messageId: string) {
+  return {
+    description:
+      'Handles the final order placement logic including auth and chat saving',
+    parameters: PlaceFinalOrderSchema,
+    generate: async function ({
+      content
+    }: z.infer<typeof PlaceFinalOrderSchema>) {
+      modifyToolAIState(history, [
+        {
+          toolCallId: messageId,
+          toolName: TOOL_FUNCTIONS.PLACE_FINAL_ORDER,
+          result: {
+            message: content
+          }
+        }
+      ] as ToolContent)
+      return (
+        <BotMessage key={messageId} content={content}>
+          <UserDetailsForm messageId={messageId} />
+        </BotMessage>
+      )
+    }
+  }
+}
+
 export const getToolFunctions = (history: any, messageId: string) => {
   return {
     renderButtons: renderButtonsTool(history, messageId),
@@ -234,6 +263,7 @@ export const getToolFunctions = (history: any, messageId: string) => {
     renderColorLabelPickerSet: renderColorLabelPickerSet(history, messageId),
     renderRegionManager: renderRegionManager(history, messageId),
     renderTextInputGroup: renderTextInputGroup(history, messageId),
-    generateCanopyMockups: generateCanopyMockups(history, messageId)
+    generateCanopyMockups: generateCanopyMockups(history, messageId),
+    placeFinalOrder: placeFinalOrder(history, messageId)
   }
 }

--- a/lib/ai-tools/utils.tsx
+++ b/lib/ai-tools/utils.tsx
@@ -93,6 +93,8 @@ const getToolMessage = (content: ToolContent): ClientMessage => {
             <ChatActionMultiSelector {...props} messageId={toolCallId} />
           </>
         )
+      case TOOL_FUNCTIONS.PLACE_FINAL_ORDER:
+        return null
 
       default:
         return null

--- a/lib/ai-tools/utils.tsx
+++ b/lib/ai-tools/utils.tsx
@@ -97,11 +97,7 @@ const getToolMessage = (content: ToolContent): ClientMessage => {
       case TOOL_FUNCTIONS.PLACE_FINAL_ORDER:
         return (
           <>
-            <UserDetailsForm
-              {...props}
-              messageId={toolCallId}
-              disabled={true}
-            />
+            <UserDetailsForm {...props} messageId={toolCallId} />
           </>
         )
 

--- a/lib/ai-tools/utils.tsx
+++ b/lib/ai-tools/utils.tsx
@@ -97,7 +97,11 @@ const getToolMessage = (content: ToolContent): ClientMessage => {
       case TOOL_FUNCTIONS.PLACE_FINAL_ORDER:
         return (
           <>
-            <UserDetailsForm {...props} messageId={toolCallId} />
+            <UserDetailsForm
+              {...props}
+              messageId={toolCallId}
+              disabled={true}
+            />
           </>
         )
 

--- a/lib/ai-tools/utils.tsx
+++ b/lib/ai-tools/utils.tsx
@@ -15,6 +15,7 @@ import { ChatTextInputGroup } from '@/components/chat-text-input-group'
 import { ColorLabelPickerSet } from '@/components/color-label-picker-set'
 import ChatActionMultiSelector from '@/components/chat-action-multi-selector'
 import RegionsColorsManager from '@/components/regions_colors_manager'
+import { UserDetailsForm } from '@/components/user-details-form'
 
 const createInitialAIState = (): Chat => {
   const chatId = nanoid()
@@ -94,7 +95,11 @@ const getToolMessage = (content: ToolContent): ClientMessage => {
           </>
         )
       case TOOL_FUNCTIONS.PLACE_FINAL_ORDER:
-        return null
+        return (
+          <>
+            <UserDetailsForm {...props} messageId={toolCallId} />
+          </>
+        )
 
       default:
         return null

--- a/lib/schemas/signupSchema.ts
+++ b/lib/schemas/signupSchema.ts
@@ -3,16 +3,9 @@ import { z } from 'zod'
 
 export const SignupSchema = z.object({
   email: z.string().email({ message: 'Invalid email address' }),
-  username: z
-    .string()
-    .min(3, { message: 'Username must be at least 3 characters long' })
-    .max(20, { message: 'Username must be less than 20 characters long' }),
   phoneNumber: z
     .string()
-    .regex(PHONE_REGEX, { message: 'Invalid phone number format' }),
-  password: z
-    .string()
-    .min(6, { message: 'Password must be at least 6 characters long' })
+    .regex(PHONE_REGEX, { message: 'Invalid phone number format' })
 })
 
 export type SignupData = z.infer<typeof SignupSchema>


### PR DESCRIPTION
## Description

This PR corresponds to the following tasks:

- [Restrict Chat History Panel for Anonymous Users](https://www.notion.so/conradlabshq/FE-Restrict-Chat-History-Panel-for-Anonymous-Users-1c3512441d3c803cbfc3dd70e91a8215?pvs=4)
- [Allow Anonymous Users to Generate Mockups](https://www.notion.so/conradlabshq/FE-Allow-Anonymous-Users-to-Generate-Mockups-1c3512441d3c8021b19fc2dcee5c8ccd?pvs=4)

In this PR, we removed the authentication flow; users can now generate mockups without being logged in, and are authenticated automatically when they place an order.

## Screenshots 

Please refer to the following screenshots

<img width="1212" alt="Screenshot 2025-04-07 at 11 21 18 AM" src="https://github.com/user-attachments/assets/64f8b7a5-473f-4b81-b447-824d99b76051" />
<img width="1212" alt="Screenshot 2025-04-07 at 11 20 32 AM" src="https://github.com/user-attachments/assets/2983d667-fd1d-483d-a5e7-21a576396c38" />
