### PR TITLE
Feat: Disable chat after final order has been placed

### DIFF
--- a/components/prompt-form.tsx
+++ b/components/prompt-form.tsx
@@ -114,7 +114,7 @@ export function PromptForm({ session }: { session?: Session }) {
           <div className="left-0 top-[14px] size-8 rounded-full bg-background p-0 sm:left-4">
             <FileUploadPopover
               onFileSelect={handleFileSelect}
-              disabled={!lastFileUploadMessage || loading}
+              disabled={!lastFileUploadMessage || loading || aiState.complete}
             />
           </div>
           <Textarea
@@ -131,7 +131,7 @@ export function PromptForm({ session }: { session?: Session }) {
             rows={1}
             value={input}
             onChange={e => setInput(e.target.value)}
-            disabled={loading || lastFileUploadMessage}
+            disabled={loading || lastFileUploadMessage || aiState.complete}
           />
           <div className="right-0 top-[13px] sm:right-4">
             <Tooltip>
@@ -141,6 +141,7 @@ export function PromptForm({ session }: { session?: Session }) {
                   size="icon"
                   disabled={
                     loading ||
+                    aiState.complete ||
                     (lastFileUploadMessage && selectedFiles.length === 0)
                   }
                   className="bg-action-button hover:bg-action-button text-action-button-foreground"

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -54,7 +54,7 @@ export const PROMPT_INSTRUCTIONS = `
         2. When email and phone number are provided, EXPLICITLY CALL the showUserDetails tool with the following parameters:
           - {email}: {email}
           - {phoneNumber}: {phoneNumber}
-          - {content}: "Your order has been placed with the following details:\n\n - Email: {email}\n - Phone number: {phoneNumber}\n\n Thank you for choosing Custom Canopy!"
+          - {content}: "Your order has been placed with the following details:\n\n - Email: {email}\n - Phone number: {phoneNumber}\n\n Thank you for choosing Custom Canopy, you can generate more mockups by starting a new chat!"
         - DO NOT generate mockups at this step.
 
 

--- a/lib/ai-tools/tool-functions.tsx
+++ b/lib/ai-tools/tool-functions.tsx
@@ -273,6 +273,13 @@ export function showUserDetails(history: any, messageId: string) {
           }
         }
       ] as ToolContent)
+
+      const current = history.get()
+      history.done({
+        ...current,
+        complete: true
+      })
+
       return <BotMessage key={messageId} content={content} />
     }
   }

--- a/lib/ai-tools/utils.tsx
+++ b/lib/ai-tools/utils.tsx
@@ -30,7 +30,8 @@ const createInitialAIState = (): Chat => {
     ],
     path: `/${CHAT}/${chatId}`,
     createdAt: new Date(),
-    loading: false
+    loading: false,
+    complete: false
   }
 }
 


### PR DESCRIPTION
## Description

This PR corresponds to the following [task](https://www.notion.so/conradlabshq/FE-Disable-text-input-after-order-has-been-placed-1ce512441d3c80c0b901e5991df5c4c3?pvs=4)

A user cannot continue a conversation in which the final order has been placed, and is instead prompted to start a new chat.