### PR TITLE
feat: Add customizable color swatcher with support for hex and RGB color

### DIFF
--- a/app/constants.ts
+++ b/app/constants.ts
@@ -68,3 +68,18 @@ export const GUIDANCE_IMAGE_URLS = {
   'top-view-light':
     'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/top-labelled-uG0O3WNkHZb5wguwPjdrtbDcbc7MBW.png'
 }
+
+export const COLOR_SWATCHES = [
+  { name: 'White', rgb: '[255, 255, 255]', hex: '#FFFFFF' },
+  { name: 'Red', rgb: '[213, 0, 50]', hex: '#D50032' },
+  { name: 'Pink', rgb: '[227, 28, 121]', hex: '#E31C79' },
+  { name: 'Purple', rgb: '[88, 44, 131]', hex: '#582C83' },
+  { name: 'Navy Blue', rgb: '[0, 32, 91]', hex: '#00205B' },
+  { name: 'Sky Blue', rgb: '[65, 182, 230]', hex: '#41B6E6' },
+  { name: 'Lime Green', rgb: '[151, 215, 0]', hex: '#97D700' },
+  { name: 'Brown', rgb: '[78, 54, 41]', hex: '#4E3629' },
+  { name: 'Dark Green', rgb: '[21, 71, 52]', hex: '#154734' },
+  { name: 'Reflex Blue', rgb: '[0, 20, 137]', hex: '#001489' },
+  { name: 'Yellow', rgb: '[254, 221, 0]', hex: '#FEDD00' },
+  { name: 'Black', rgb: '[45, 41, 38]', hex: '#2D2926' }
+]

--- a/components/chat-color-picker-wrapper.tsx
+++ b/components/chat-color-picker-wrapper.tsx
@@ -4,6 +4,7 @@ import ColorPicker from './color-picker'
 import { useActions, useUIState, useAIState } from 'ai/rsc'
 import { UserMessage } from './stocks/message'
 import { nanoid } from '@/lib/utils'
+import { Color } from '@/lib/types'
 
 interface ChatColorPickerWrapperProps {
   messageId: string
@@ -16,18 +17,16 @@ export const ChatColorPickerWrapper = ({
   const [messages, setMessages] = useUIState()
   const [aiState, _setAIState] = useAIState()
 
-  const handleColorPick = async (color: string, colorName: string) => {
+  const handleColorPick = async (color: Color) => {
     setMessages((currentConversation: any) => [
       ...currentConversation,
       {
         id: nanoid(),
         role: 'user',
-        display: <UserMessage content={JSON.stringify({ color, colorName })} />
+        display: <UserMessage content={JSON.stringify(color)} />
       }
     ])
-    const message = await submitUserMessage(
-      JSON.stringify({ color, colorName })
-    )
+    const message = await submitUserMessage(JSON.stringify(color))
     setMessages((currentMessages: any) => [...currentMessages, message])
   }
 

--- a/components/chat-color-swatcher-wrapper.tsx
+++ b/components/chat-color-swatcher-wrapper.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useActions, useUIState, useAIState } from 'ai/rsc'
+import ColorSwatcher from './color-swatcher'
+import { Color } from '@/lib/types'
+
+interface ChatColorSwatcherWrapperProps {
+  messageId: string
+  color?: Color | null
+}
+
+export const ChatColorSwatcherWrapper = ({
+  messageId,
+  color = null
+}: ChatColorSwatcherWrapperProps) => {
+  const { submitUserMessage } = useActions()
+  const [messages, setMessages] = useUIState()
+  const [aiState, _setAIState] = useAIState()
+
+  const handleColorPick = async (color: Color) => {
+    const message = await submitUserMessage(JSON.stringify({ color }))
+    setMessages((currentMessages: any) => [...currentMessages, message])
+  }
+
+  return (
+    <ColorSwatcher
+      currentColor={color}
+      onColorSelect={handleColorPick}
+      disabled={messageId !== messages.at(-1)?.id || aiState.loading}
+    />
+  )
+}

--- a/components/color-label-picker-set.tsx
+++ b/components/color-label-picker-set.tsx
@@ -3,12 +3,13 @@
 import { useState } from 'react'
 import { useActions, useUIState } from 'ai/rsc'
 import ColorPickerWithLabel from './color-picker-with-label'
+import { Color } from '@/lib/types'
 
 interface ColorLabelPickerSetProps {
   fieldColors: {
     name: string
     label: string
-    color: { name: string; value: string }
+    color: Color
   }[]
   messageId?: string
   setFieldColors?: (sides: any) => void
@@ -22,13 +23,7 @@ export const ColorLabelPickerSet = ({
   const { submitUserMessage } = useActions()
   const [messages, setMessages] = useUIState()
   const [fields, setFields] = useState(fieldColors || [])
-  const handleColorPickerSelect = (
-    fieldName: string,
-    colorObj: {
-      name: string
-      value: string
-    }
-  ) => {
+  const handleColorPickerSelect = (fieldName: string, colorObj: Color) => {
     const updatedFields = fields.map(field =>
       field.label === fieldName ? { ...field, color: colorObj } : field
     )
@@ -40,7 +35,7 @@ export const ColorLabelPickerSet = ({
       fields.map(field => ({
         [field.name]: {
           [field.label]: {
-            color: { color: field.color.value, colorName: field.color.name }
+            color: field.color
           }
         }
       }))
@@ -58,9 +53,11 @@ export const ColorLabelPickerSet = ({
           currentColor={field.color}
           disabled={
             messageId !== messages.at(-1)?.id ||
-            fields.some(field => field.color.value === '')
+            fields.some(field => field.color.rgb === '')
           }
-          onColorSelect={handleColorPickerSelect}
+          onColorSelect={(color: Color) =>
+            handleColorPickerSelect(field.label, color)
+          }
         />
       ))}
       {!setFieldColors && (
@@ -69,7 +66,7 @@ export const ColorLabelPickerSet = ({
           onClick={onSubmit}
           disabled={
             messageId !== messages.at(-1)?.id ||
-            fields.some(field => field.color.value === '')
+            fields.some(field => field.color.rgb === '')
           }
         >
           Okay

--- a/components/color-picker-with-label.tsx
+++ b/components/color-picker-with-label.tsx
@@ -1,13 +1,11 @@
 import { useState } from 'react'
-import ColorPickerPopover from './color-picker'
+import { Color } from '@/lib/types'
+import ColorSwatcherPopover from './color-swatcher-popover'
 
 interface ColorPickerWithLabelProps {
   label: string
-  currentColor: { name: string; value: string }
-  onColorSelect: (
-    fieldName: string,
-    { name, value }: { name: string; value: string }
-  ) => void
+  currentColor: Color
+  onColorSelect: (color: Color) => void
   disabled?: boolean
 }
 
@@ -17,18 +15,11 @@ const ColorPickerWithLabel: React.FC<ColorPickerWithLabelProps> = ({
   onColorSelect,
   disabled = false
 }) => {
-  const [color, setColor] = useState<{ name: string; value: string }>(
-    currentColor
-  )
+  const [color, setColor] = useState<Color>(currentColor)
 
-  const handleColorSelect = (
-    colorValue: string,
-    colorName: string,
-    _fontColor: string
-  ) => {
-    const colorObj = { name: colorName, value: colorValue }
-    setColor(colorObj)
-    onColorSelect(label, colorObj)
+  const handleColorSelect = (color: Color) => {
+    setColor(color)
+    onColorSelect(color)
   }
 
   return (
@@ -44,13 +35,14 @@ const ColorPickerWithLabel: React.FC<ColorPickerWithLabelProps> = ({
           <span
             className="w-10 h-5 border border-gray-300 dark:border-gray-700"
             style={{
-              backgroundColor: `rgb(${JSON.parse(color.value).join(',')})`
+              backgroundColor: color.hex
             }}
           ></span>
           <span className="text-gray-700 dark:text-gray-300">{color.name}</span>
         </div>
       )}
-      <ColorPickerPopover
+      <ColorSwatcherPopover
+        currentColor={color}
         onColorSelect={handleColorSelect}
         label={color ? 'Change Color' : 'Pick a Color'}
         disabled={disabled}

--- a/components/color-picker.tsx
+++ b/components/color-picker.tsx
@@ -2,12 +2,13 @@ import { useState } from 'react'
 import { HexColorPicker } from 'react-colorful'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 import { Button } from '@/components/ui/button'
-import { getColorName } from '@/lib/utils'
+import { getColorName, hexToBGR } from '@/lib/utils'
 import { IconColorPicker } from './ui/icons'
 import { COLORS } from '@/app/constants'
+import { Color } from '@/lib/types'
 
 interface ColorPickerPopoverProps {
-  onColorSelect: (color: string, colorName: string, fontColor: string) => void
+  onColorSelect: (color: Color, fontColor: string) => void
   disabled: boolean
   label?: string
 }
@@ -19,15 +20,6 @@ export default function ColorPickerPopover({
 }: Readonly<ColorPickerPopoverProps>) {
   const [color, setColor] = useState('#000000')
   const [isPickerOpen, setPickerOpen] = useState(false)
-
-  const hexToBGR = (hex: string): any => {
-    const bigint = parseInt(hex.slice(1), 16)
-    const r = (bigint >> 16) & 255
-    const g = (bigint >> 8) & 255
-    const b = bigint & 255
-
-    return { r, g, b }
-  }
 
   const handleColorChange = (newColor: string) => {
     setColor(newColor)
@@ -48,7 +40,10 @@ export default function ColorPickerPopover({
     const contrastFontColor = getContrastColor(b, g, r)
     const colorName = getColorName(color) ?? color
     const rgbColor = `[${r}, ${g}, ${b}]`
-    onColorSelect(rgbColor, colorName, contrastFontColor)
+    onColorSelect(
+      { rgb: rgbColor, hex: color, name: colorName },
+      contrastFontColor
+    )
     setPickerOpen(false)
   }
 

--- a/components/color-swatcher-popover.tsx
+++ b/components/color-swatcher-popover.tsx
@@ -33,7 +33,7 @@ export default function ColorSwatcherPopover({
           size="icon"
           className="flex items-center gap-2 w-full p-2 disabled:cursor-not-allowed"
           disabled={disabled}
-          onClick={() => setPickerOpen(false)}
+          onClick={() => setPickerOpen(!isPickerOpen)}
         >
           <IconColorPicker />
           <span>{label}</span>

--- a/components/color-swatcher-popover.tsx
+++ b/components/color-swatcher-popover.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
+import { Button } from '@/components/ui/button'
+import { IconColorPicker } from './ui/icons'
+import { Color } from '@/lib/types'
+import ColorSwatcher from './color-swatcher'
+
+interface ColorSwatcherPopoverProps {
+  currentColor: Color | null
+  onColorSelect: (color: Color) => void
+  disabled: boolean
+  label?: string
+}
+
+export default function ColorSwatcherPopover({
+  currentColor,
+  onColorSelect,
+  disabled,
+  label = 'Pick a color'
+}: Readonly<ColorSwatcherPopoverProps>) {
+  const [isPickerOpen, setPickerOpen] = useState(false)
+
+  const handleColorSelect = (color: Color) => {
+    onColorSelect(color)
+    setPickerOpen(false)
+  }
+
+  return (
+    <Popover open={isPickerOpen && !disabled} onOpenChange={setPickerOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          className="flex items-center gap-2 w-full p-2 disabled:cursor-not-allowed"
+          disabled={disabled}
+          onClick={() => setPickerOpen(false)}
+        >
+          <IconColorPicker />
+          <span>{label}</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="center" side="top" className="w-full">
+        <ColorSwatcher
+          currentColor={currentColor}
+          disabled={disabled}
+          onColorSelect={handleColorSelect}
+        />
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/components/color-swatcher.tsx
+++ b/components/color-swatcher.tsx
@@ -37,7 +37,7 @@ const ColorSwatcher = ({
       const { r, g, b } = hexToBGR(hex)
       handleColorPick({
         hex,
-        rgb: JSON.stringify(`[${r}, ${g}, ${b}]`),
+        rgb: JSON.stringify([r, g, b]),
         name: getColorName(hex) ?? 'Custom'
       })
     } else {
@@ -94,7 +94,7 @@ const ColorSwatcher = ({
               )
             }
             value={selectedColor?.hex ?? ''}
-            placeholder="#000000"
+            placeholder={COLOR_SWATCHES[0].hex}
             error={isValidHex ? '' : 'Invalid HEX'}
             onChange={handleInputChange}
             disabled={disabled}

--- a/components/color-swatcher.tsx
+++ b/components/color-swatcher.tsx
@@ -1,0 +1,116 @@
+import { COLOR_SWATCHES } from '@/app/constants'
+import React, { useState } from 'react'
+import TextInputWithLabel from './ui/text-input-with-label'
+import { getColorName, validateHEX, hexToBGR } from '@/lib/utils'
+import { Color } from '@/lib/types'
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip'
+
+interface ColorSwatcherProps {
+  currentColor: Color | null
+  onColorSelect: (color: Color) => void
+  disabled: boolean
+}
+
+const ColorSwatcher = ({
+  currentColor,
+  onColorSelect,
+  disabled
+}: ColorSwatcherProps) => {
+  const [selectedColor, setSelectedColor] = useState<Color | null>(currentColor)
+  const [isValidHex, setIsValidHex] = useState<boolean>(true)
+
+  const handleColorPick = (color: Color) => {
+    if (color.name === selectedColor?.name) {
+      setSelectedColor(null)
+    } else {
+      setSelectedColor(color)
+    }
+  }
+
+  const handleInputChange = (hex: string) => {
+    if (hex === '') {
+      setIsValidHex(true)
+      return
+    }
+    if (validateHEX(hex)) {
+      setIsValidHex(true)
+      const { r, g, b } = hexToBGR(hex)
+      handleColorPick({
+        hex,
+        rgb: JSON.stringify(`[${r}, ${g}, ${b}]`),
+        name: getColorName(hex) ?? 'Custom'
+      })
+    } else {
+      setIsValidHex(false)
+    }
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (selectedColor) {
+      onColorSelect(selectedColor)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-4 mx-auto">
+      <div className="p-4 bg-white dark:bg-gray-800 rounded-lg shadow">
+        <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-3 mb-4">
+          {COLOR_SWATCHES.map(color => (
+            <Tooltip key={color.name}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={color.name}
+                  className="w-12 h-12 rounded border-2 border-transparent hover:border-gray-500 cursor-pointer flex items-center justify-center mx-auto mb-1 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-transparent"
+                  style={{ backgroundColor: color.hex }}
+                  onClick={() => handleColorPick(color)}
+                  disabled={disabled}
+                />
+              </TooltipTrigger>
+              <TooltipContent>{color.name}</TooltipContent>
+            </Tooltip>
+          ))}
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="flex items-center w-full gap-2"
+        >
+          <TextInputWithLabel
+            label={
+              selectedColor?.name ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      className="w-full h-5 flex items-center justify-between"
+                      style={{ backgroundColor: selectedColor.hex }}
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent>{selectedColor.name}</TooltipContent>
+                </Tooltip>
+              ) : (
+                'Custom'
+              )
+            }
+            value={selectedColor?.hex ?? ''}
+            placeholder="#000000"
+            error={isValidHex ? '' : 'Invalid HEX'}
+            onChange={handleInputChange}
+            disabled={disabled}
+            maxLength={7}
+          />
+          <button
+            type="submit"
+            disabled={disabled || !isValidHex || !selectedColor?.hex}
+            className="chat-button w-1/4"
+          >
+            Apply
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default ColorSwatcher

--- a/components/regions_colors_manager.tsx
+++ b/components/regions_colors_manager.tsx
@@ -10,6 +10,7 @@ interface RegionColorsManagerProps {
   regions: {
     name: string
     sides: {
+      name: string
       label: string
       color: Color
     }[]

--- a/components/regions_colors_manager.tsx
+++ b/components/regions_colors_manager.tsx
@@ -4,14 +4,14 @@ import { useState } from 'react'
 import { useActions, useUIState } from 'ai/rsc'
 import { ColorLabelPickerSet } from './color-label-picker-set'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs'
+import { Color } from '@/lib/types'
 
 interface RegionColorsManagerProps {
   regions: {
     name: string
     sides: {
-      name: string
       label: string
-      color: { name: string; value: string }
+      color: Color
     }[]
   }[]
   messageId?: string
@@ -27,15 +27,7 @@ const RegionsColorsManager = ({
 
   const submitRegionData = async () => {
     const serializedRegions = JSON.stringify({
-      regions: regionData.map(({ name, sides }) => ({
-        [name]: sides.map(({ name, label, color }) => ({
-          [name]: {
-            [label]: {
-              color: { color: color.value, colorName: color.name }
-            }
-          }
-        }))
-      }))
+      regions: regionData
     })
 
     const newMessage = await submitUserMessage(serializedRegions)

--- a/components/ui/text-input-with-label.tsx
+++ b/components/ui/text-input-with-label.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from 'react'
 type TextInputWithLabelProps = {
   label: string | React.ReactNode
   value: string
-  error: string
+  error?: string
   onChange: (value: string) => void
   [key: string]: any
 }

--- a/components/ui/text-input-with-label.tsx
+++ b/components/ui/text-input-with-label.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 type TextInputWithLabelProps = {
-  label: string
+  label: string | React.ReactNode
   value: string
+  error: string
   onChange: (value: string) => void
   [key: string]: any
 }
@@ -12,6 +13,7 @@ type TextInputWithLabelProps = {
 const TextInputWithLabel = ({
   label,
   value,
+  error,
   onChange,
   ...rest
 }: TextInputWithLabelProps) => {
@@ -23,23 +25,29 @@ const TextInputWithLabel = ({
     onChange(newValue)
   }
 
+  useEffect(() => {
+    setText(value)
+  }, [value])
+
   return (
-    <div className="flex items-center border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm">
-      <label
-        htmlFor="text-input"
-        className="px-4 py-2 text-base font-medium text-gray-700 dark:text-gray-300 border-r border-gray-300 dark:border-gray-700 min-w-[20%]"
-      >
-        {label}
-      </label>
-      <input
-        id="text-input"
-        type="text"
-        value={text}
-        onChange={handleChange}
-        placeholder="Enter something..."
-        className={`w-full px-4 py-2 text-base text-gray-800 dark:text-gray-200 dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 error:border-red-500`}
-        {...rest}
-      />
+    <div className="flex flex-col gap-2 w-full">
+      <div className="flex items-center border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm">
+        <label
+          htmlFor="text-input"
+          className="px-4 py-2 text-base font-medium text-gray-700 dark:text-gray-300 border-r border-gray-300 dark:border-gray-700 min-w-[20%] w-fit"
+        >
+          {label}
+        </label>
+        <input
+          id="text-input"
+          type="text"
+          value={text}
+          onChange={handleChange}
+          placeholder="Enter something..."
+          className={`w-full px-4 py-2 text-base text-gray-800 dark:text-gray-200 dark:bg-gray-800 focus:outline-none focus:ring-1 ${error ? 'focus:ring-red-500 focus:border-red-500 border-red-500' : 'focus:ring-blue-500 focus:border-blue-500'}`}
+          {...rest}
+        />
+      </div>
     </div>
   )
 }

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -11,8 +11,8 @@ export const PROMPT_INSTRUCTIONS = `
   Question # 2. **Color Selection**:
   - Ask the user to select a color for the canopy by calling the renderColorPicker tool:
   - ALWAYS EXPLICITLY CALL the renderColorPicker tool for user color selection.
-  - Accept the user answer in RGB color values
-  - Set the user selected color for the valences (front, back, left, right) and peaks (front, back, left, right) and proceed
+  - Accept the user answer in format: {name, hex, rgb}
+  - Set the user selected color in rgb for the valences (front, back, left, right) and peaks (front, back, left, right) and proceed
   - The user answer here will refer to the initial/default color selection for the canopy.  
     
   Question # 3. **Logo Upload**:
@@ -20,22 +20,7 @@ export const PROMPT_INSTRUCTIONS = `
     - {content}: ["Please upload your company logo to be displayed on the canopy."]
 
   Question #4. **Generate Mockups Before Add-ons:**
-    - Once the primary color and logo are provided:
-      1. Show user selections in unordered list format and confirm with the user to generate mockups by EXPLICITLY CALLING the renderButtons tool:
-         - {content}:
-          - "Would you like to generate mockups with the current selections?"
-          - Company Name: {companyName}
-          - Canopy type: {canopyType}
-          - Colors: {colors} 
-            If the user has selected a color, display the color in a small square next to the color name.
-          - Logo: <img src={logo} alt="Logo" width="150" height="150" />
-          - Add-ons [MENTION THIS AS SUB-LIST ONLY IF ATLEAST ONE ADD-ON IS SELECTED BY THE USER]
-
-         - {options}: [
-             { "name": "Yes, generate mockups", "value": "generate-mockups", selected: [isAlreadySelected] },
-             { "name": "No, I need to make changes", "value": "no, edit", selected: [isAlreadySelected] }
-           ]
-      2. If the user selects "Yes, generate mockups," EXPLICITLY CALL the generateCanopyMockups tool and display the mockups to the user.
+    - Once the primary color and logo are provided, EXPLICITLY CALL the generateCanopyMockups tool and display the mockups to the user.
         - Set the companyName for the valences texts (front, back, left, right) as default/initial state for valences if valence texts are not already set and proceed
         - Set the user selected color for the valences (front, back, left, right) and peaks (front, back, left, right) as default/initial state for regions if colors are not already set and proceed
         - Tent type is no-walls here
@@ -49,12 +34,10 @@ export const PROMPT_INSTRUCTIONS = `
       3. If the user selects "No," ask them which details they want to change, make the updates.
 
       ** Place order Workflow:** (If the user clicks on "Place order" button)
-        1. If the "Place Order" option is selected, EXPLICITLY CALL the placeFinalOrder tool with the following parameters:
-          - {content}: "Please provide the following information:"
-        2. When email and phone number are provided, EXPLICITLY CALL the showUserDetails tool with the following parameters:
-          - {email}: {email}
-          - {phoneNumber}: {phoneNumber}
-          - {content}: "Your order has been placed with the following details:\n\n - Email: {email}\n - Phone number: {phoneNumber}\n\n Thank you for choosing Custom Canopy!"
+        If the "Place Order" option is selected, 
+          - If the user email and phone number both are provided, inform the user about the order placement by mentioning the email and phone number order is placed on.
+          - Otherwise, if the user email and phone number are not provided, MAKE SURE TO EXPLICITLY call the "placeFinalOrder" tool function with the following format:
+            - {content}: {assistantMessage asking user for details to place the order}
         - DO NOT generate mockups at this step.
 
 
@@ -67,8 +50,8 @@ export const PROMPT_INSTRUCTIONS = `
       - If the user selects "Separate Colors":
         1. Manage the regions colors using the "renderRegionManager" tool using the below format:
         {regions}: [
-            [name: 'Peaks', content: {assistantResponse}, sides: [{name: Peaks, label: "Front", color: {selectedRegion.front.colorname, selectedRegion.front.value}, {name: Peaks, label: "Back", color: selectedRegion.back}, {name: Peaks, label: "Left", color: selectedRegion.left}, {name: Peaks, label: "Right", color: selectedRegion.right}],
-            {name: Valences, content: {assistantResponse}, sides: [{name: Valences, label: "Front", color: {selectedRegion.front.colorname, selectedRegion.front.value}, {name: Valences, label: "Back", color: selectedRegion.back}, {name: Valences, label: "Left", color: selectedRegion.left}, {name: Valences, label: "Right", color: selectedRegion.right}],
+            [name: 'Peaks', content: {assistantResponse}, sides: [{name: Peaks, label: "Front", color: {selectedRegion.front}, {name: Peaks, label: "Back", color: selectedRegion.back}, {name: Peaks, label: "Left", color: selectedRegion.left}, {name: Peaks, label: "Right", color: selectedRegion.right}],
+            {name: Valences, content: {assistantResponse}, sides: [{name: Valences, label: "Front", color: {selectedRegion.front}, {name: Valences, label: "Back", color: selectedRegion.back}, {name: Valences, label: "Left", color: selectedRegion.left}, {name: Valences, label: "Right", color: selectedRegion.right}],
             {name: Walls, content: {assistantResponse}, sides: [{name: Walls, label: "Back", color: selectedRegion.back}, {name: Walls, label: "Left", color: selectedRegion.left}, {name: Walls, label: "Right", color: selectedRegion.right}]  ONLY IF THE USER SELECTED "Half Walls"
         ]
         2. The user does not need to change all the colors in a region. 
@@ -146,7 +129,7 @@ export const PROMPT_INSTRUCTIONS = `
     - For text, logo, or company name changes, only request updated inputs for the specified fields.
     - If the user want to edit colors for a specific region, EXPLICITLY CALL the renderColorLabelPickerSet tool function using the format 
       {content}: "Please select the colors for the {region}."
-      {fieldColors}: [{name: region, label: "Front", color: {selectedRegion.front.colorname, selectedRegion.front.value}, {name: region, label: "Back", color: selectedRegion.back}, {name: region, label: "Left", color: selectedRegion.left}, {name: region, label: "Right", color: selectedRegion.right}]
+      {fieldColors}: [{name: region, label: "Front", color: {selectedRegion.front}, {name: region, label: "Back", color: selectedRegion.back}, {name: region, label: "Left", color: selectedRegion.left}, {name: region, label: "Right", color: selectedRegion.right}]
 
   Let's begin creating your custom canopy!
 ]`
@@ -158,8 +141,7 @@ export const TOOL_FUNCTIONS = {
   RENDER_COLOR_LABEL_PICKER_SET: 'renderColorLabelPickerSet',
   RENDER_REGION_MANAGER: 'renderRegionManager',
   GENERATE_CANOPY_MOCKUPS: 'generateCanopyMockups',
-  PLACE_FINAL_ORDER: 'placeFinalOrder',
-  SHOW_USER_DETAILS: 'showUserDetails'
+  PLACE_FINAL_ORDER: 'placeFinalOrder'
 }
 
 export const INITIAL_CHAT_MESSAGE =

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -141,7 +141,8 @@ export const TOOL_FUNCTIONS = {
   RENDER_COLOR_LABEL_PICKER_SET: 'renderColorLabelPickerSet',
   RENDER_REGION_MANAGER: 'renderRegionManager',
   GENERATE_CANOPY_MOCKUPS: 'generateCanopyMockups',
-  PLACE_FINAL_ORDER: 'placeFinalOrder'
+  PLACE_FINAL_ORDER: 'placeFinalOrder',
+  SHOW_USER_DETAILS: 'showUserDetails'
 }
 
 export const INITIAL_CHAT_MESSAGE =

--- a/lib/ai-tools/schemas.ts
+++ b/lib/ai-tools/schemas.ts
@@ -48,7 +48,8 @@ export const ColorLabelPickerSetSchema = z.object({
         label: z.string().describe('The label for the color picker'),
         color: z.object({
           name: z.string().describe('The color name'),
-          value: z.string().describe('The color value')
+          rgb: z.string().describe('The color value in rgb'),
+          hex: z.string().describe('The color value in hex')
         })
       })
     )
@@ -68,7 +69,8 @@ export const RegionsColorsManagerSchema = z.object({
             label: z.string().describe('The value for the button'),
             color: z.object({
               name: z.string().describe('The name for the button'),
-              value: z.string().describe('The value for the button')
+              rgb: z.string().describe('The color value in rgb'),
+              hex: z.string().describe('The color value in hex')
             })
           })
         )

--- a/lib/ai-tools/tool-functions.tsx
+++ b/lib/ai-tools/tool-functions.tsx
@@ -14,7 +14,7 @@ import {
 import { Carousal } from '@/components/carousel'
 import { BotCard, BotMessage } from '@/components/stocks/message'
 import { ChatRadioButtonWrapper } from '@/components/chat-radio-buttons-wrapper'
-import { ChatColorPickerWrapper } from '@/components/chat-color-picker-wrapper'
+import { ChatColorSwatcherWrapper } from '@/components/chat-color-swatcher-wrapper'
 import { generateTentMockupsApi } from '../redux/apis/tent-mockup-prompt'
 import { MockupResponse, Roles, TentMockUpPrompt } from '../types'
 import { TOOL_FUNCTIONS } from './constants'
@@ -79,7 +79,7 @@ export function renderColorPickerTool(history: any, messageId: string) {
 
       return (
         <BotMessage key={messageId} content={content}>
-          <ChatColorPickerWrapper messageId={messageId} />
+          <ChatColorSwatcherWrapper messageId={messageId} />
         </BotMessage>
       )
     }

--- a/lib/ai-tools/utils.tsx
+++ b/lib/ai-tools/utils.tsx
@@ -1,7 +1,7 @@
 import { convertToCoreMessages, CoreMessage, ToolContent } from 'ai'
 import { BotMessage, UserMessage } from '@/components/stocks/message'
 import { ChatRadioButtonWrapper } from '@/components/chat-radio-buttons-wrapper'
-import { ChatColorPickerWrapper } from '@/components/chat-color-picker-wrapper'
+import { ChatColorSwatcherWrapper } from '@/components/chat-color-swatcher-wrapper'
 import { Chat, ClientMessage, Roles, ToolCallResult } from '@/lib/types'
 import { CHAT, IMAGE } from '@/app/constants'
 import { isValidJson, nanoid } from '@/lib/utils'
@@ -76,7 +76,7 @@ const getToolMessage = (content: ToolContent): ClientMessage => {
         return <ChatRadioButtonWrapper messageId={toolCallId} {...props} />
 
       case TOOL_FUNCTIONS.RENDER_COLOR_PICKER:
-        return <ChatColorPickerWrapper messageId={toolCallId} />
+        return <ChatColorSwatcherWrapper messageId={toolCallId} {...props} />
 
       case TOOL_FUNCTIONS.RENDER_TEXT_INPUT_GROUP:
         return <ChatTextInputGroup messageId={toolCallId} {...props} />
@@ -149,8 +149,7 @@ const getClientMessages = (messages: CoreMessage[]): ClientMessage[] => {
     const nextMessage = messages[i + 1]
     if (
       currentMessage.role === Roles.tool &&
-      nextMessage?.role === Roles.user &&
-      currentMessage.content[0].toolName !== TOOL_FUNCTIONS.RENDER_COLOR_PICKER
+      nextMessage?.role === Roles.user
     ) {
       let updatedProps = (currentMessage.content[0].result as ToolCallResult)
         .props
@@ -170,7 +169,6 @@ const getClientMessages = (messages: CoreMessage[]): ClientMessage[] => {
           }
         }
       ]
-
       i = i + 1
     }
     clientMessages.push(getClientMessage(currentMessage))

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -155,3 +155,9 @@ export type EditableOption = {
   selected: boolean
   edit?: boolean
 }
+
+export type Color = {
+  rgb: string
+  hex: string
+  name: string
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -131,26 +131,28 @@ export function getColorName(hexColor: string): string | null {
   return namedColor ? namedColor.name : null
 }
 
-function rgbToHex(rgbColor: string) {
-  const rgb = JSON.parse(rgbColor)
-  const [r, g, b] = rgb
-  if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255) {
-    throw new Error('RGB values must be between 0 and 255.')
-  }
+export const hexToBGR = (hex: string): any => {
+  const bigint = parseInt(hex.slice(1), 16)
+  const r = (bigint >> 16) & 255
+  const g = (bigint >> 8) & 255
+  const b = bigint & 255
 
-  const toHex = (value: number) =>
-    value.toString(16).padStart(2, '0').toUpperCase()
-
-  return `#${toHex(r)}${toHex(g)}${toHex(b)}`
+  return { r, g, b }
 }
 
-export function getRGBColorName(rgbColor: string): string | null {
-  const hexColor = rgbToHex(rgbColor)
-  return getColorName(hexColor)
+export function validateHEX(input: string) {
+  const hexRegex = /^#([0-9A-Fa-f]{6})$/
+  return hexRegex.test(input)
 }
 export const convertToBGR = (rgb: string) => {
   const [r, g, b] = JSON.parse(rgb)
   return `[${b}, ${g}, ${r}]`
+}
+
+export const toCamelCase = (str: string) => {
+  return str
+    .toLowerCase()
+    .replace(/[^a-zA-Z0-9]+(.)/g, (m, chr) => chr.toUpperCase())
 }
 
 export const isValidJson = (jsonString: string) => {


### PR DESCRIPTION
## Description

This PR corresponds to the following tasks
- [FE-Implement-Customizable-Color-Swatcher](https://www.notion.so/conradlabshq/FE-Implement-Customizable-Color-Swatcher-1cf512441d3c804fa801cc8236cda900?pvs=4)
- [FE-Generate-mockups-upon-logo-upload](https://www.notion.so/conradlabshq/FE-Generate-mockups-upon-logo-upload-1cf512441d3c8080946dc42a78a5ce06?pvs=4)

### Changes Made

1. **Customizable Color Swatcher**:
   - Added Color Swatcher component with support for `hex` and `rgb` color formats.
   - Dynamic addition of new colors with proper validation.

2. **Integration with Tools**:
   - Added proper handling for saving color data via chat tool calls, ensuring relevant properties are passed effectively.
   - Modified a mockup generation tool call specifically for handling logo additions.

3. Fixes and Improvements
- Fixed existing issues related to color format inconsistencies.
- Refactored overall logic to align with the new color type object structure.

## Screenshots

Please refer to the following screenshots

- Before the UI changes
<img width="807" alt="Screenshot 2025-04-10 at 3 14 36 PM" src="https://github.com/user-attachments/assets/2007f5f0-c2b2-4040-9eb3-8d1ff20e63e1" />
<img width="762" alt="Screenshot 2025-04-10 at 3 15 10 PM" src="https://github.com/user-attachments/assets/13e90c15-f48f-4f0a-b7df-ab9361a6afb1" />


- After the UI changes
<img width="482" alt="Screenshot 2025-04-10 at 2 16 49 PM" src="https://github.com/user-attachments/assets/e9d24233-b9bc-4376-bcdd-389e889ef10e" />

<img width="1512" alt="Screenshot 2025-04-10 at 2 15 19 PM" src="https://github.com/user-attachments/assets/5e31c5b3-9005-435b-821a-d0d12f287b02" />
