### PR TITLE
Feat: Allow users to choose text color

### DIFF
--- a/app/constants.ts
+++ b/app/constants.ts
@@ -83,3 +83,5 @@ export const COLOR_SWATCHES = [
   { name: 'Yellow', rgb: '[254, 221, 0]', hex: '#FEDD00' },
   { name: 'Black', rgb: '[45, 41, 38]', hex: '#2D2926' }
 ]
+
+export const HEX_REGEX = /^#([0-9A-Fa-f]{6})$/

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -20,8 +20,8 @@ export const PROMPT_INSTRUCTIONS = `
   - Ask the user to select a color for the text by calling the renderColorPicker tool:
   - {content}: "Please select a color for the text on your canopy."
   - ALWAYS EXPLICITLY CALL the renderColorPicker tool for user color selection.
-  - Accept the user answer in RGB color values
-  - Set the user selected color to be the text color
+  - Accept the user answer in format: {name, hex, rgb}
+  - Set the user selected color in rgb to be the text color
   - The user answer here will refer to the initial/default color of the text on the canopy.
     
   Question # 4. **Logo Upload**:

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -10,16 +10,25 @@ export const PROMPT_INSTRUCTIONS = `
 
   Question # 2. **Color Selection**:
   - Ask the user to select a color for the canopy by calling the renderColorPicker tool:
+  - {content}: "Please select a color for your canopy."
   - ALWAYS EXPLICITLY CALL the renderColorPicker tool for user color selection.
   - Accept the user answer in RGB color values
   - Set the user selected color for the valences (front, back, left, right) and peaks (front, back, left, right) and proceed
-  - The user answer here will refer to the initial/default color selection for the canopy.  
+  - The user answer here will refer to the initial/default color selection for the canopy.
+
+  Question # 3. **Text Color Selection**:
+  - Ask the user to select a color for the text by calling the renderColorPicker tool:
+  - {content}: "Please select a color for the text on your canopy."
+  - ALWAYS EXPLICITLY CALL the renderColorPicker tool for user color selection.
+  - Accept the user answer in RGB color values
+  - Set the user selected color to be the text color
+  - The user answer here will refer to the initial/default color of the text on the canopy.
     
-  Question # 3. **Logo Upload**:
+  Question # 4. **Logo Upload**:
     - Prompt the user to upload their logo:
     - {content}: ["Please upload your company logo to be displayed on the canopy."]
 
-  Question #4. **Generate Mockups Before Add-ons:**
+  Question #5. **Generate Mockups Before Add-ons:**
     - Once the primary color and logo are provided:
       1. Show user selections in unordered list format and confirm with the user to generate mockups by EXPLICITLY CALLING the renderButtons tool:
          - {content}:

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -149,12 +149,6 @@ export const convertToBGR = (rgb: string) => {
   return `[${b}, ${g}, ${r}]`
 }
 
-export const toCamelCase = (str: string) => {
-  return str
-    .toLowerCase()
-    .replace(/[^a-zA-Z0-9]+(.)/g, (m, chr) => chr.toUpperCase())
-}
-
 export const isValidJson = (jsonString: string) => {
   try {
     JSON.parse(jsonString)

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -3,6 +3,7 @@ import { customAlphabet } from 'nanoid'
 import { twMerge } from 'tailwind-merge'
 import namer from 'color-namer'
 import { ResultCode } from '../types'
+import { HEX_REGEX } from '@/app/constants'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -141,8 +142,7 @@ export const hexToBGR = (hex: string): any => {
 }
 
 export function validateHEX(input: string) {
-  const hexRegex = /^#([0-9A-Fa-f]{6})$/
-  return hexRegex.test(input)
+  return HEX_REGEX.test(input)
 }
 export const convertToBGR = (rgb: string) => {
   const [r, g, b] = JSON.parse(rgb)

--- a/lib/utils/tent-mockup.ts
+++ b/lib/utils/tent-mockup.ts
@@ -1,5 +1,4 @@
 import { TentMockUpPrompt } from '../types'
-import { COLORS } from '@/app/constants'
 
 interface TentMockUpPromptFormData extends TentMockUpPrompt {
   logoFile: File
@@ -16,7 +15,8 @@ export const createFormData = (
     peaks,
     walls,
     valences,
-    valencesTexts
+    valencesTexts,
+    fontColor
   } = mockUpPrompt
   const formRequestBody = new FormData()
 
@@ -38,7 +38,7 @@ export const createFormData = (
   })
 
   formRequestBody.append('logo', logoFile)
-  formRequestBody.append('text_color', COLORS.BLACK_COLOR)
+  formRequestBody.append('text_color', fontColor)
   if (tableColor) formRequestBody.append('table_color', tableColor)
   formRequestBody.append('output_dir', `chat:${id}`)
 

--- a/lib/utils/tent-mockup.ts
+++ b/lib/utils/tent-mockup.ts
@@ -34,7 +34,7 @@ export const createFormData = (
   })
 
   Object.entries(valencesTexts).forEach(([key, value]) => {
-    formRequestBody.append(`${key}_text`, value)
+    formRequestBody.append(`${key}_text`, value.toUpperCase())
   })
 
   formRequestBody.append('logo', logoFile)


### PR DESCRIPTION
## Description

This PR corresponds to the following [task](https://www.notion.so/conradlabshq/Allow-user-to-change-font-color-1d0512441d3c80b09088fb3be5da1eb6?pvs=4)

A user now picks the color of the text that will appear on the canopy

## Dependent On

- [feat: Add customizable color swatcher with support for hex and RGB color](https://github.com/AwaisKamran/custom-canopy-chatbot-app/pull/34)