### PR TITLE
Fix/Guidance Tab Images

### DIFF
--- a/app/constants.ts
+++ b/app/constants.ts
@@ -51,20 +51,56 @@ export const MOCKUP_TYPES = {
 export const DOWNLOAD_ZIP_NAME = 'images'
 
 export const GUIDANCE_IMAGE_URLS = {
-  'front-dark':
-    'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/front-labelled-dark-VzclXjdoIMmGF7N97rTtWO5CFx92mZ.png',
-  'front-light':
-    'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/front-labelled-kMelSxI1m9YFs20hfzW3qyfyWSNOpg.png',
-  'no-walls-dark':
-    'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/no-walls-labelled-dark-rr7cSQbPtKOml8DA32tLLMpi7rlhjV.png',
-  'no-walls-light':
-    'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/no-walls-labelled-UXrfUttKUDGdAZkzyC9cbbVLEve0Yg.png',
-  'half-wall-dark':
-    'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/side-labelled-dark-lokRZkxCDmacR00ZK7QSDm73Yj5Qui.png',
-  'half-wall-light':
-    'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/side-labelled-zBUEx9GMyq1rOp0MembizovFNwurbj.png',
-  'top-view-dark':
-    'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/top-labelled-dark-lsbx0BHr6fqEY93d1gsSCxXlO1qB49.png',
-  'top-view-light':
-    'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/top-labelled-uG0O3WNkHZb5wguwPjdrtbDcbc7MBW.png'
+  dark: {
+    canopy: [
+      {
+        filename: 'Front View',
+        url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/dark/front-DnKuv1U8WUFyV7cwPpTFmNSaMWyNP7.png'
+      },
+      // {
+      //   filename: 'No Walls View',
+      //   url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/no-walls-labelled-dark-rr7cSQbPtKOml8DA32tLLMpi7rlhjV.png'
+      // },
+      {
+        filename: 'Side View',
+        url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/dark/half-walls-PLdoyKU7DHBOioX9JB6lIXOH5F7Zyh.png'
+      },
+      {
+        filename: 'Top View',
+        url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/dark/top-view-ORDGOIiq5KxKpT2dpjUWCC4QRaIQMF.png'
+      }
+    ],
+    table: [
+      {
+        filename: 'Table',
+        url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/dark/table-OqtfnAmQIGUDiNHersEB2CNpCEoypu.png'
+      }
+    ]
+  },
+  light: {
+    canopy: [
+      {
+        filename: 'Front View',
+        url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/light/front-52JArz8sEDOyvSC7mmZkeK3Hq1cUFh.png'
+      },
+      // {
+      //   filename: 'No Walls View',
+      //   url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/light/half-walls-499r5GYDKNkTmlKd8rEGvTlAIVsLfS.png'
+      // },
+      {
+        filename: 'Side View',
+        url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/side-labelled-zBUEx9GMyq1rOp0MembizovFNwurbj.png'
+      },
+      {
+        filename: 'Top View',
+        url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/light/top-view-cOYUspNcRtfFM35sZoTdGFXLEoSZQ1.png'
+      }
+    ],
+    table: [
+      {
+        filename: 'Table',
+        url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/light/table-qXl2boQQaUmxI9EnOAm774E8HQAvE8.png'
+      }
+    ]
+  }
 }

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -57,10 +57,10 @@ export const GUIDANCE_IMAGE_URLS = {
         filename: 'Front View',
         url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/dark/front-DnKuv1U8WUFyV7cwPpTFmNSaMWyNP7.png'
       },
-      // {
-      //   filename: 'No Walls View',
-      //   url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/no-walls-labelled-dark-rr7cSQbPtKOml8DA32tLLMpi7rlhjV.png'
-      // },
+      {
+        filename: 'No Walls View',
+        url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/no-walls-labelled-dark-rr7cSQbPtKOml8DA32tLLMpi7rlhjV.png'
+      },
       {
         filename: 'Side View',
         url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/dark/half-walls-PLdoyKU7DHBOioX9JB6lIXOH5F7Zyh.png'
@@ -83,10 +83,10 @@ export const GUIDANCE_IMAGE_URLS = {
         filename: 'Front View',
         url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/light/front-52JArz8sEDOyvSC7mmZkeK3Hq1cUFh.png'
       },
-      // {
-      //   filename: 'No Walls View',
-      //   url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/light/half-walls-499r5GYDKNkTmlKd8rEGvTlAIVsLfS.png'
-      // },
+      {
+        filename: 'No Walls View',
+        url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/light/half-walls-499r5GYDKNkTmlKd8rEGvTlAIVsLfS.png'
+      },
       {
         filename: 'Side View',
         url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/side-labelled-zBUEx9GMyq1rOp0MembizovFNwurbj.png'

--- a/app/globals.css
+++ b/app/globals.css
@@ -43,6 +43,8 @@
     --action-button: 199, 47%, 88%;
     --action-button-foreground: 223, 4%, 36%;
 
+    --carousal: 0 0% 100%;
+
     --border: 0, 0%, 66%;
     --input: 240 5.9% 90%;
     --ring: 240 10% 3.9%;
@@ -89,6 +91,8 @@
 
     --action-button: 191, 38%, 48%;
     --action-button-foreground: 0, 0%, 100%;
+
+    --carousal: 199, 67%, 11%;
  
     --border: 0, 0%, 66%;
     --input: 240 3.7% 15.9%;

--- a/components/carousel.tsx
+++ b/components/carousel.tsx
@@ -25,15 +25,17 @@ export const Carousal = ({
   const [images, setImages] = useState<Image[]>([])
 
   useEffect(() => {
-    const images: Image[] = Object.entries(mockups).map(([key, value]) => ({
-      url: value.url,
-      contentType: value.contentType,
-      filename:
-        key in MOCKUP_TYPES
-          ? MOCKUP_TYPES[key as keyof typeof MOCKUP_TYPES]
-          : key
-    }))
-    setImages(images)
+    if (mockups) {
+      const images: Image[] = Object.entries(mockups).map(([key, value]) => ({
+        url: value?.url,
+        contentType: value?.contentType,
+        filename:
+          key in MOCKUP_TYPES
+            ? MOCKUP_TYPES[key as keyof typeof MOCKUP_TYPES]
+            : key
+      }))
+      setImages(images)
+    }
   }, [mockups])
 
   const handleDownload = async () => {

--- a/components/guidance-image-view.tsx
+++ b/components/guidance-image-view.tsx
@@ -12,18 +12,25 @@ export function GuidanceImageView({
   images,
   setIsCarouselOpen,
   setInitialIndex
-}: GuidanceImageViewProps) {
+}: Readonly<GuidanceImageViewProps>) {
   if (!images) {
     return
   }
 
+  const singleImage = images.length === 1
   return (
-    <>
+    <div className="mt-6">
       {images.map((image, index) => {
         return (
-          <div key={image.filename} className="mb-6">
-            <p className="text-sm mb-4">{image.filename}</p>
-            <div className="relative border-0.5 border-action-button rounded-md rounded-tr-none p-1 overflow-auto">
+          <div key={image.filename} className={singleImage ? 'my-4' : ''}>
+            {!singleImage && (
+              <p
+                className={`text-xs text-muted-foreground ${singleImage ? 'my-0' : 'my-2'}`}
+              >
+                {image.filename}
+              </p>
+            )}
+            <div className="relative border-0.5 !border-action-button dark:!border-active-button rounded-md rounded-tr-none overflow-auto p-2">
               <Button
                 variant="ghost"
                 size="icon"
@@ -40,12 +47,12 @@ export function GuidanceImageView({
               <img
                 src={image.url}
                 alt={image.filename}
-                className="w-[300px] h-[200px] object-contain rounded"
+                className="w-[250px] h-[214px] object-contain rounded"
               />
             </div>
           </div>
         )
       })}
-    </>
+    </div>
   )
 }

--- a/components/guidance.tsx
+++ b/components/guidance.tsx
@@ -4,9 +4,9 @@ import { ThemeToggle } from './theme-toggle'
 import { Image } from '@/lib/types'
 
 interface GuidanceProps {
-  images: Image[]
+  images: { [key: string]: Image[] }
   setIsCarouselOpen: (isOpen: boolean) => void
-  setInitialIndex: (index: number) => void
+  setInitialIndex: (keyIndex: number, index: number) => void
 }
 
 export function Guidance({
@@ -32,13 +32,16 @@ export function Guidance({
           <br />
           Valence = the portion which connects with the peak
         </p>
-
-        <GuidanceImageView
-          images={images}
-          setIsCarouselOpen={setIsCarouselOpen}
-          setInitialIndex={setInitialIndex}
-        />
-
+        {Object.entries(images).map(([key, values], keyIndex) => {
+          return (
+            <GuidanceImageView
+              key={`${key}-${keyIndex}`}
+              images={values}
+              setIsCarouselOpen={setIsCarouselOpen}
+              setInitialIndex={index => setInitialIndex(keyIndex, index)}
+            />
+          )
+        })}
         <div className="flex justify-end">
           <ThemeToggle />
         </div>

--- a/components/preview-carousel.tsx
+++ b/components/preview-carousel.tsx
@@ -49,10 +49,10 @@ export default function PreviewCarousel({
       onClick={onClose}
     >
       <div
-        className="relative w-[70vw] max-w-4xl bg-background rounded-none shadow-lg"
+        className="relative w-full max-w-xl xl:max-w-6xl lg:max-w-6xl md:max-w-3xl sm:max-w-xl xs:max-w-xl bg-carousal rounded-none shadow-lg"
         onClick={e => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between w-full pl-4 bg-indigo-100 text-neutral-900 font-normal">
+        <div className="flex items-center justify-between w-full pl-4 bg-action-button text-action-button-foreground font-normal">
           <div className="flex-1">{images[activeIndex || 0]?.filename}</div>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -62,17 +62,17 @@ export default function PreviewCarousel({
                 onClick={onClose}
                 className={cn(
                   'chat-button',
-                  'my-0 rounded-none bg-action-button border-none hover:bg-action-button text-action-button-foreground border-none'
+                  'my-0 rounded-none bg-active-button border-none hover:bg-active-button text-active-button-foreground border-none'
                 )}
               >
-                <IconClose className="w-4 h-4 fill-action-button-foreground" />
+                <IconClose className="w-4 h-4 fill-active-button-foreground" />
                 <span className="sr-only">Close Carousel</span>
               </Button>
             </TooltipTrigger>
             <TooltipContent>Close Carousel</TooltipContent>
           </Tooltip>
         </div>
-        <Carousel className="w-full p-8" setApi={setApi}>
+        <Carousel className="w-full p-8 pb-6" setApi={setApi}>
           <CarouselContent>
             {images.map(
               (image: { filename: string; url: string }, index: number) => (
@@ -84,32 +84,33 @@ export default function PreviewCarousel({
                     <img
                       src={image.url}
                       alt={`Image ${index} (${image.filename})`}
-                      className="w-auto h-[400px] sm:rounded-md"
+                      className="w-auto h-[500px] sm:rounded-md"
                     />
                   </div>
                 </CarouselItem>
               )
             )}
           </CarouselContent>
-          <div className="flex items-center justify-center gap-4 pt-6">
+          <div className="flex items-center justify-center gap-4 pt-4">
             <CarouselPrevious className="relative" variant="ghost" />
-            <div className="flex gap-2 overflow-x-auto">
-              {images.map(
-                (image: { filename: string; url: string }, index: number) => (
+            <div className="flex items-center justify-center gap-2 overflow-x-auto p-2">
+              {images.map((image, index) => (
+                <button
+                  key={`thumbnail-${index}`}
+                  onClick={() => api?.scrollTo(index)}
+                  className={`transition-transform duration-300 flex-shrink-0 cursor-pointer bg-white dark:bg-active-button shadow-md ${
+                    index === activeIndex
+                      ? 'p-2 w-[110px] h-[80px]'
+                      : 'p-1 w-[92px] h-[67px]'
+                  } rounded-lg overflow-hidden`}
+                >
                   <img
-                    key={index}
                     src={image.url}
                     alt={`Thumbnail ${index}`}
-                    onClick={() => api?.scrollTo(index)}
-                    className={cn(
-                      'w-20 h-20 object-contain rounded-md cursor-pointer border-2 transition bg-background p-1',
-                      activeIndex === index
-                        ? 'border-primary'
-                        : 'border-accent opacity-60 hover:opacity-100'
-                    )}
+                    className="w-full h-full object-contain"
                   />
-                )
-              )}
+                </button>
+              ))}
             </div>
             <CarouselNext className="relative" variant="ghost" />
           </div>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -3,57 +3,41 @@
 import * as React from 'react'
 
 import { useSidebar } from '@/lib/hooks/use-sidebar'
-import { cn } from '@/lib/utils'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs'
 import { Guidance } from './guidance'
 import PreviewCarousel from './preview-carousel'
 import { Image } from '@/lib/types'
 import { useTheme } from 'next-themes'
 import { GUIDANCE_IMAGE_URLS } from '@/app/constants'
+import { calculateIndex, cn } from '@/lib/utils'
 
 export interface SidebarProps extends React.ComponentProps<'div'> {}
 
 export function Sidebar({ className, children }: SidebarProps) {
   const { isSidebarOpen, isLoading } = useSidebar()
-  const [images, setImages] = React.useState<Image[]>([])
+  const [images, setImages] = React.useState<{ [key: string]: Image[] }>({})
   const [isCarouselOpen, setIsCarouselOpen] = React.useState(false)
   const [initialIndex, setInitialIndex] = React.useState(0)
   const { theme } = useTheme()
 
-  React.useEffect(() => {
-    const images: Image[] = [
-      {
-        filename: 'Front View',
-        url:
-          theme === 'light'
-            ? GUIDANCE_IMAGE_URLS['front-light']
-            : GUIDANCE_IMAGE_URLS['front-dark']
-      },
-      {
-        filename: 'Side View',
-        url:
-          theme === 'light'
-            ? GUIDANCE_IMAGE_URLS['half-wall-light']
-            : GUIDANCE_IMAGE_URLS['half-wall-dark']
-      },
-      {
-        filename: 'Top View',
-        url:
-          theme === 'light'
-            ? GUIDANCE_IMAGE_URLS['top-view-light']
-            : GUIDANCE_IMAGE_URLS['top-view-dark']
-      },
-      {
-        filename: 'No Walls View',
-        url:
-          theme === 'light'
-            ? GUIDANCE_IMAGE_URLS['no-walls-light']
-            : GUIDANCE_IMAGE_URLS['no-walls-dark']
-      }
-    ]
+  const getSystemTheme = () => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    return mediaQuery.matches ? 'dark' : 'light'
+  }
 
-    setImages(images)
+  React.useEffect(() => {
+    if (theme === 'system') {
+      const systemTheme = getSystemTheme()
+      setImages(GUIDANCE_IMAGE_URLS[systemTheme])
+    } else {
+      setImages(theme ? GUIDANCE_IMAGE_URLS[theme] : GUIDANCE_IMAGE_URLS.light)
+    }
   }, [theme])
+
+  const handleSetInitialIndex = (keyIndex: number, index: number) => {
+    const idx = calculateIndex(keyIndex, index, images)
+    setInitialIndex(idx)
+  }
 
   return (
     <>
@@ -73,13 +57,13 @@ export function Sidebar({ className, children }: SidebarProps) {
           <Guidance
             images={images}
             setIsCarouselOpen={setIsCarouselOpen}
-            setInitialIndex={setInitialIndex}
+            setInitialIndex={handleSetInitialIndex}
           />
         </TabsContent>
       </Tabs>
 
       <PreviewCarousel
-        images={images}
+        images={Object.values(images).flat()}
         isOpen={isCarouselOpen}
         onClose={() => setIsCarouselOpen(false)}
         initialIndex={initialIndex}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -30,7 +30,11 @@ export function Sidebar({ className, children }: SidebarProps) {
       const systemTheme = getSystemTheme()
       setImages(GUIDANCE_IMAGE_URLS[systemTheme])
     } else {
-      setImages(theme ? GUIDANCE_IMAGE_URLS[theme] : GUIDANCE_IMAGE_URLS.light)
+      setImages(
+        theme
+          ? GUIDANCE_IMAGE_URLS[theme as 'dark' | 'light']
+          : GUIDANCE_IMAGE_URLS.light
+      )
     }
   }, [theme])
 

--- a/components/ui/radio-button-group.tsx
+++ b/components/ui/radio-button-group.tsx
@@ -49,7 +49,7 @@ export const RadioButtonGroup = ({
   return (
     <div className="w-full flex flex-col gap-2 items-center">
       <div className="grid grid-cols-2 gap-2 w-full self-start">
-        {options.map((option, index) => (
+        {options?.map((option, index) => (
           <div key={option.value} className="relative w-full">
             <button
               key={option.value}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -2,7 +2,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { customAlphabet } from 'nanoid'
 import { twMerge } from 'tailwind-merge'
 import namer from 'color-namer'
-import { ResultCode } from '../types'
+import { Image, ResultCode } from '../types'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -160,4 +160,16 @@ export const isValidJson = (jsonString: string) => {
   } catch (e) {
     return false
   }
+}
+
+export function calculateIndex(
+  keyindex: number,
+  index: number,
+  items: { [key: string]: Image[] }
+): number {
+  const totalBefore = Object.values(items)
+    .slice(0, keyindex)
+    .reduce((sum, item) => sum + item.length, 0)
+
+  return totalBefore + keyindex * index + index
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -27,6 +27,7 @@ module.exports = {
         ring: 'hsl(var(--ring))',
         background: 'hsl(var(--background))',
         foreground: 'hsl(var(--foreground))',
+        carousal: 'hsl(var(--carousal))',
         primary: {
           DEFAULT: 'hsl(var(--primary))',
           foreground: 'hsl(var(--primary-foreground))'
@@ -96,8 +97,8 @@ module.exports = {
         'accordion-up': 'accordion-up 0.2s ease-out'
       },
       borderWidth: {
-        '0.5': '0.5px',
-      },
+        '0.5': '0.5px'
+      }
     }
   },
   plugins: [require('tailwindcss-animate'), require('@tailwindcss/typography')]


### PR DESCRIPTION
## Description

This PR corresponds to [Add-New-URLs-for-Guidance-Tab-and-Related-Enhancements](https://www.notion.so/conradlabshq/Add-New-URLs-for-Guidance-Tab-and-Related-Enhancements-1d1512441d3c80608f19e418d48dc5b5?pvs=4)

### Changes  
   - Included the required routes and configurations for the new guidance tab functionality.  
   - Updated the system theme to align with the new guidance tab integration.  
   - Refined UI elements with updated styling and integrated new images to enhance visual consistency and appeal.  
   - Improved code structure and readability to support the newly added features and ensure maintainability.  


## Screenshots

Please refer to the following screenshots

- Before the UI changes
<img width="1512" alt="Screenshot 2025-04-10 at 6 24 17 PM" src="https://github.com/user-attachments/assets/2680e0e5-7248-489a-8a3b-314918ee6247" />
<img width="1512" alt="Screenshot 2025-04-10 at 6 24 33 PM" src="https://github.com/user-attachments/assets/40e93bd3-44da-4e17-aa3f-f3372d44b16d" />

- After the UI changes

<img width="1512" alt="Screenshot 2025-04-10 at 6 23 55 PM" src="https://github.com/user-attachments/assets/d07282f4-afad-4f77-9804-de25a19ff6bf" />
<img width="1512" alt="Screenshot 2025-04-10 at 6 24 07 PM" src="https://github.com/user-attachments/assets/b6f7df2f-58cd-4ee1-814f-4a546c89998f" />
