### PR TITLE
Fix: Fix user details form repetition, update UI and increase determinism of questions

### DIFF
--- a/app/(chat)/actions.tsx
+++ b/app/(chat)/actions.tsx
@@ -27,7 +27,7 @@ export async function submitUserMessage(
   const messageId = nanoid()
   const ui = await streamUI({
     model: openai('gpt-4o'),
-    temperature: 0.3,
+    temperature: 0.1,
     messages: [
       {
         role: Roles.system,

--- a/app/(chat)/actions.tsx
+++ b/app/(chat)/actions.tsx
@@ -27,7 +27,7 @@ export async function submitUserMessage(
   const messageId = nanoid()
   const ui = await streamUI({
     model: openai('gpt-4o'),
-    temperature: 0.1,
+    temperature: 0.2,
     messages: [
       {
         role: Roles.system,

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,35 @@
+import { getUser } from '@/app/login/actions'
+import { authConfig } from '@/auth.config'
+import NextAuth from 'next-auth'
+import Credentials from 'next-auth/providers/credentials'
+import { z } from 'zod'
+
+export const {
+  handlers: { GET, POST }
+} = NextAuth({
+  ...authConfig,
+  providers: [
+    Credentials({
+      async authorize(credentials) {
+        const parsedCredentials = z
+          .object({
+            email: z.string().email()
+          })
+          .safeParse(credentials)
+
+        if (
+          parsedCredentials &&
+          parsedCredentials.success &&
+          parsedCredentials.data
+        ) {
+          const { email } = parsedCredentials.data
+          const user = await getUser(email)
+
+          if (user) return user
+        }
+
+        return null
+      }
+    })
+  ]
+})

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -54,20 +54,20 @@ export const GUIDANCE_IMAGE_URLS = {
   dark: {
     canopy: [
       {
-        filename: 'Front View',
-        url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/dark/front-DnKuv1U8WUFyV7cwPpTFmNSaMWyNP7.png'
-      },
-      {
         filename: 'No Walls View',
         url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/no-walls-labelled-dark-rr7cSQbPtKOml8DA32tLLMpi7rlhjV.png'
       },
       {
-        filename: 'Side View',
-        url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/dark/half-walls-PLdoyKU7DHBOioX9JB6lIXOH5F7Zyh.png'
-      },
-      {
         filename: 'Top View',
         url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/dark/top-view-ORDGOIiq5KxKpT2dpjUWCC4QRaIQMF.png'
+      },
+      {
+        filename: 'Front View',
+        url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/dark/front-DnKuv1U8WUFyV7cwPpTFmNSaMWyNP7.png'
+      },
+      {
+        filename: 'Side View',
+        url: 'https://xyvvsdhvfprf3oqa.public.blob.vercel-storage.com/custom-canopy-server-static/templates/dark/half-walls-PLdoyKU7DHBOioX9JB6lIXOH5F7Zyh.png'
       }
     ],
     table: [

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,34 +8,11 @@ import { Providers } from '@/components/providers'
 import { Header } from '@/components/header'
 import { Toaster } from '@/components/ui/sonner'
 
-export const metadata = {
-  metadataBase: process.env.VERCEL_URL
-    ? new URL(`https://${process.env.VERCEL_URL}`)
-    : undefined,
-  title: {
-    default: 'Next.js AI Chatbot',
-    template: `%s - Next.js AI Chatbot`
-  },
-  description: 'An AI-powered chatbot template built with Next.js and Vercel.',
-  icons: {
-    icon: '/favicon.ico',
-    shortcut: '/favicon-16x16.png',
-    apple: '/apple-touch-icon.png'
-  }
-}
-
-export const viewport = {
-  themeColor: [
-    { media: '(prefers-color-scheme: light)', color: 'white' },
-    { media: '(prefers-color-scheme: dark)', color: 'black' }
-  ]
-}
-
 interface RootLayoutProps {
   children: React.ReactNode
 }
 
-export default function RootLayout({ children }: RootLayoutProps) {
+export default function RootLayout({ children }: Readonly<RootLayoutProps>) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -11,8 +11,6 @@ import { Session } from '@/lib/types'
 import { usePathname } from 'next/navigation'
 import { useScrollAnchor } from '@/lib/hooks/use-scroll-anchor'
 import { toast } from 'sonner'
-import { CHAT } from '@/app/constants'
-import { nanoid } from 'nanoid'
 
 export interface ChatProps extends React.ComponentProps<'div'> {
   className?: string
@@ -21,14 +19,8 @@ export interface ChatProps extends React.ComponentProps<'div'> {
 }
 
 export function Chat({ className, session, missingKeys }: ChatProps) {
-  const path = usePathname()
   const [aiState, _setAIState] = useAIState()
   const [_, setNewChatId] = useLocalStorage('newChatId', aiState.id)
-  useEffect(() => {
-    if (!path.includes(CHAT)) {
-      window.history.replaceState({}, '', aiState.path)
-    }
-  }, [aiState.id, path])
 
   useEffect(() => {
     setNewChatId(aiState.id)

--- a/components/color-swatcher.tsx
+++ b/components/color-swatcher.tsx
@@ -79,19 +79,23 @@ const ColorSwatcher = ({
         >
           <TextInputWithLabel
             label={
-              selectedColor?.name ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span
-                      className="w-full h-5 flex items-center justify-between"
-                      style={{ backgroundColor: selectedColor.hex }}
-                    />
-                  </TooltipTrigger>
-                  <TooltipContent>{selectedColor.name}</TooltipContent>
-                </Tooltip>
-              ) : (
-                'Custom'
-              )
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className="w-full h-5 flex items-center justify-center px-2 py-1 rounded"
+                    style={
+                      selectedColor?.name
+                        ? { backgroundColor: selectedColor.hex }
+                        : {}
+                    }
+                  >
+                    {!selectedColor?.name && 'Custom'}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {selectedColor?.name ?? 'Custom'}
+                </TooltipContent>
+              </Tooltip>
             }
             value={selectedColor?.hex ?? ''}
             placeholder="#000000"

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -4,18 +4,24 @@ import * as React from 'react'
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
 import { ThemeProviderProps } from 'next-themes/dist/types'
 import { SidebarProvider } from '@/lib/hooks/use-sidebar'
+import { SessionProvider } from 'next-auth/react'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { Provider } from 'react-redux'
 import { store } from '../lib/redux/store'
 
-export function Providers({ children, ...props }: ThemeProviderProps) {
+export function Providers({
+  children,
+  ...props
+}: Readonly<ThemeProviderProps>) {
   return (
-    <NextThemesProvider {...props}>
-      <SidebarProvider>
-        <TooltipProvider>
-          <Provider store={store}>{children}</Provider>
-        </TooltipProvider>
-      </SidebarProvider>
-    </NextThemesProvider>
+    <SessionProvider>
+      <NextThemesProvider {...props}>
+        <SidebarProvider>
+          <TooltipProvider>
+            <Provider store={store}>{children}</Provider>
+          </TooltipProvider>
+        </SidebarProvider>
+      </NextThemesProvider>
+    </SessionProvider>
   )
 }

--- a/components/ui/text-input-with-label.tsx
+++ b/components/ui/text-input-with-label.tsx
@@ -7,6 +7,7 @@ type TextInputWithLabelProps = {
   value: string
   error?: string
   onChange: (value: string) => void
+  type?: string
   [key: string]: any
 }
 
@@ -15,12 +16,27 @@ const TextInputWithLabel = ({
   value,
   error,
   onChange,
+  type,
   ...rest
 }: TextInputWithLabelProps) => {
   const [text, setText] = useState(value)
 
+  function formatPhoneNumber(value: string): string {
+    const digits = value.replace(/\D/g, '')
+
+    const length = digits.length
+    if (length === 0) return ''
+    if (length < 4) return digits
+    if (length < 7) return `(${digits.slice(0, 3)}) ${digits.slice(3)}`
+    return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6, 10)}`
+  }
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = e.target.value
+    let newValue = e.target.value
+    if (type === 'tel') {
+      newValue = formatPhoneNumber(newValue)
+    }
+
     setText(newValue)
     onChange(newValue)
   }
@@ -43,7 +59,6 @@ const TextInputWithLabel = ({
           type="text"
           value={text}
           onChange={handleChange}
-          placeholder="Enter something..."
           className={`w-full px-4 py-2 text-base text-gray-800 dark:text-gray-200 dark:bg-gray-800 focus:outline-none focus:ring-1 ${error ? 'focus:ring-red-500 focus:border-red-500 border-red-500' : 'focus:ring-blue-500 focus:border-blue-500'}`}
           {...rest}
         />

--- a/components/user-details-form.tsx
+++ b/components/user-details-form.tsx
@@ -1,10 +1,6 @@
 'use client'
 
-import { authenticateOrSignup } from '@/app/login/actions'
 import { useAIState, useUIState, useActions } from 'ai/rsc'
-import { toast } from 'sonner'
-import { getMessageFromCode } from '@/lib/utils'
-import { saveChat } from '@/app/actions'
 
 export interface UserDetailsFormProps {
   messageId: string
@@ -27,22 +23,13 @@ export function UserDetailsForm({
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     const formData = new FormData(e.currentTarget)
-    const result = await authenticateOrSignup(undefined, formData)
-    if (result?.type === 'success') {
-      const jsonResult = Object.fromEntries(formData.entries())
-      await submitResponse(
-        JSON.stringify({
-          mockupRequestId: mockupRequestId
-        })
-      )
-      toast.success(getMessageFromCode(result.resultCode))
-    } else {
-      console.error(result?.resultCode)
-      const error = result?.resultCode
-        ? getMessageFromCode(result.resultCode)
-        : 'An unexpected error occurred, please try again later!'
-      toast.error(error)
-    }
+    const jsonResult = Object.fromEntries(formData.entries())
+    await submitResponse(
+      JSON.stringify({
+        ...jsonResult,
+        mockupRequestId: mockupRequestId
+      })
+    )
   }
 
   return (

--- a/components/user-details-form.tsx
+++ b/components/user-details-form.tsx
@@ -13,7 +13,7 @@ import { useRouter } from 'next/navigation'
 
 export interface UserDetailsFormProps {
   messageId: string
-  inputFields: {
+  userFields: {
     label: string
     value: string
     disabled?: boolean
@@ -24,14 +24,14 @@ export interface UserDetailsFormProps {
 
 export function UserDetailsForm({
   messageId,
-  inputFields,
+  userFields,
   mockupRequestId
 }: Readonly<UserDetailsFormProps>) {
   const [messages, setMessages] = useUIState()
   const [aiState, _setAIState] = useAIState()
   const { submitUserMessage } = useActions()
   const { data, update } = useSession()
-  const [fields, setFields] = useState(inputFields)
+  const [fields, setFields] = useState(userFields)
   const router = useRouter()
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -40,7 +40,7 @@ export function UserDetailsForm({
     if (data) {
       const message = await submitUserMessage(
         JSON.stringify({
-          inputFields: fields,
+          userFields: fields,
           mockupRequestId: mockupRequestId
         }),
         true

--- a/components/user-details-form.tsx
+++ b/components/user-details-form.tsx
@@ -15,13 +15,13 @@ export function UserDetailsForm({
   messageId,
   mockupRequestId
 }: UserDetailsFormProps) {
-  const [messages, _setMessages] = useUIState()
+  const [messages, setMessages] = useUIState()
   const [aiState, _setAIState] = useAIState()
   const { submitUserMessage } = useActions()
 
   const submitResponse = async (message: string) => {
-    await submitUserMessage(message)
-    await saveChat(aiState)
+    const response = await submitUserMessage(message)
+    setMessages((currentMessages: any) => [...currentMessages, response])
   }
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {

--- a/components/user-details-form.tsx
+++ b/components/user-details-form.tsx
@@ -18,6 +18,7 @@ export interface UserDetailsFormProps {
     value: string
     disabled?: boolean
     type: string
+    placeholder: string
   }[]
   mockupRequestId: string
 }
@@ -97,6 +98,7 @@ export function UserDetailsForm({
             value={field.value}
             onChange={(value: any) => handleChange(index, value)}
             disabled={field.disabled || messageId !== messages.at(-1)?.id}
+            placeholder={field.placeholder}
             required
           />
         ))}

--- a/components/user-details-form.tsx
+++ b/components/user-details-form.tsx
@@ -1,80 +1,105 @@
 'use client'
 
+import { authenticateOrSignup } from '@/app/login/actions'
 import { useAIState, useUIState, useActions } from 'ai/rsc'
+import { toast } from 'sonner'
+import { getMessageFromCode } from '@/lib/utils'
+import { useState } from 'react'
+import TextInputWithLabel from './ui/text-input-with-label'
+import { useSession } from 'next-auth/react'
+import { ClientMessage } from '@/lib/types'
+import _ from 'lodash'
+import { useRouter } from 'next/navigation'
 
 export interface UserDetailsFormProps {
   messageId: string
+  inputFields: {
+    label: string
+    value: string
+    disabled?: boolean
+    type: string
+  }[]
   mockupRequestId: string
 }
 
 export function UserDetailsForm({
   messageId,
+  inputFields,
   mockupRequestId
-}: UserDetailsFormProps) {
+}: Readonly<UserDetailsFormProps>) {
   const [messages, setMessages] = useUIState()
   const [aiState, _setAIState] = useAIState()
   const { submitUserMessage } = useActions()
-
-  const submitResponse = async (message: string) => {
-    const response = await submitUserMessage(message)
-    setMessages((currentMessages: any) => [...currentMessages, response])
-  }
+  const { data, update } = useSession()
+  const [fields, setFields] = useState(inputFields)
+  const router = useRouter()
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    const formData = new FormData(e.currentTarget)
-    const jsonResult = Object.fromEntries(formData.entries())
-    await submitResponse(
-      JSON.stringify({
-        ...jsonResult,
-        mockupRequestId: mockupRequestId
-      })
+    const formData = new FormData()
+    if (data) {
+      const message = await submitUserMessage(
+        JSON.stringify({
+          inputFields: fields,
+          mockupRequestId: mockupRequestId
+        }),
+        true
+      )
+      setMessages((currentMessages: ClientMessage[]) => [
+        ...currentMessages,
+        message
+      ])
+      return
+    }
+    fields.forEach(field => {
+      formData.append(_.camelCase(field.label), field.value)
+    })
+    const result = await authenticateOrSignup(undefined, formData)
+    if (result?.type === 'success') {
+      await update()
+
+      const message = await submitUserMessage(
+        JSON.stringify({
+          inputFields: fields,
+          mockupRequestId: mockupRequestId
+        }),
+        true
+      )
+      setMessages((currentMessages: ClientMessage[]) => [
+        ...currentMessages,
+        message
+      ])
+      router.refresh()
+      toast.success(getMessageFromCode(result?.resultCode ?? ''))
+    } else {
+      const error = result?.resultCode
+        ? getMessageFromCode(result.resultCode)
+        : 'An unexpected error occurred, please try again later!'
+      toast.error(error)
+    }
+  }
+
+  const handleChange = (index: number, newValue: string) => {
+    const updatedFields = fields.map((field: any, i: number) =>
+      i === index ? { ...field, value: newValue } : field
     )
+    setFields(updatedFields)
   }
 
   return (
     <div className="prose break-words dark:prose-invert prose-p:leading-relaxed prose-pre:p-0">
-      <form
-        aria-disabled={messageId !== messages.at(-1)?.id || aiState.loading}
-        className="space-y-4 px-1"
-        onSubmit={handleSubmit}
-      >
-        <div>
-          <label
-            className="mb-3 block text-xs font-medium text-zinc-400"
-            htmlFor="email"
-          >
-            Email
-          </label>
-          <div className="relative">
-            <input
-              className="peer block w-full rounded-md border bg-zinc-50 px-2 py-[9px] text-sm outline-none placeholder:text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950"
-              id="email"
-              type="email"
-              name="email"
-              placeholder="Enter your email address"
-              required
-            />
-          </div>
-        </div>
-        <div>
-          <label
-            className="mb-3 mt-5 block text-xs font-medium text-zinc-400"
-            htmlFor="phoneNumber"
-          >
-            Phone Number
-          </label>
-          <div className="relative">
-            <input
-              className="peer block w-full rounded-md border bg-zinc-50 px-2 py-[9px] text-sm outline-none placeholder:text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950"
-              id="phoneNumber"
-              type="text"
-              name="phoneNumber"
-              placeholder="Enter your phone number"
-              required
-            />
-          </div>
-        </div>
+      <form className="space-y-4 px-1" onSubmit={handleSubmit}>
+        {fields?.map((field, index) => (
+          <TextInputWithLabel
+            key={`${field.label}-${index}`}
+            label={field.label}
+            type={field.type}
+            value={field.value}
+            onChange={(value: any) => handleChange(index, value)}
+            disabled={field.disabled || messageId !== messages.at(-1)?.id}
+            required
+          />
+        ))}
         <button
           type="submit"
           disabled={messageId !== messages.at(-1)?.id || aiState.loading}

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -29,27 +29,13 @@ export const PROMPT_INSTRUCTIONS = `
     - {content}: ["Please upload your company logo to be displayed on the canopy."]
 
   Question #5. **Generate Mockups Before Add-ons:**
-    - Once the primary color and logo are provided:
-      Step 1. Show user selections in unordered list format and confirm with the user to generate mockups by EXPLICITLY CALLING the renderButtons tool:
-         - {content}:
-          - "Would you like to generate mockups with the current selections?"
-          - Company Name: {companyName}
-          - Colors: {colors} 
-            If the user has selected a color, display the color in a small square next to the color name.
-          - Logo: <img src={logo} alt="Logo" width="150" height="150" />
-          - Add-ons [MENTION THIS AS SUB-LIST ONLY IF ATLEAST ONE ADD-ON IS SELECTED BY THE USER]
-
-         - {options}: [
-             { "name": "Yes, generate mockups", "value": "generate-mockups", selected: [isAlreadySelected] },
-             { "name": "No, I need to make changes", "value": "no, edit", selected: [isAlreadySelected] }
-           ]
-      Step 2. If the user selects "Yes, generate mockups," EXPLICITLY CALL the generateCanopyMockups tool.
+    - Once the primary color and logo are provided, EXPLICITLY CALL the generateCanopyMockups tool.
         - Set the companyName for the valences texts (front, back, left, right) as default/initial state for valences if valence texts are not already set and proceed
         - Set the user selected color for the valences (front, back, left, right) and peaks (front, back, left, right) as default/initial state for regions if colors are not already set and proceed
         - Tent type is no-walls here
         - {content}: "Your mockups are being generated. In the meanwhile, please provide the following information."
       
-      Step 3. As soon as user information and the mockupRequestId have been recieved, EXPLICTLY call the showGeneratedMockups tool with ALL of the following values (content, mockupRequestId, selectorName, options) to display the generated mockups:
+      Step 2. As soon as user information and the mockupRequestId have been recieved, EXPLICTLY call the showGeneratedMockups tool with ALL of the following values (content, mockupRequestId, selectorName, options) to display the generated mockups:
             - {content}: "Thank you, here are your mockups!"
             - {selectorName}: "Change mockups"
             - {options}: [

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -15,30 +15,22 @@ export const PROMPT_INSTRUCTIONS = `
   - Accept the user answer in format: {name, hex, rgb}
   - Set the user selected color in BGR (convert from RGB to BGR) for the valences (front, back, left, right) and peaks (front, back, left, right) and proceed
   - The user answer here will refer to the initial/default color selection for the canopy.
-
-  Question # 3. **Text Color Selection**:
-  - Ask the user to select a color for the text by calling the renderColorPicker tool:
-  - {content}: "Please select a color for the text on your canopy."
-  - ALWAYS EXPLICITLY CALL the renderColorPicker tool for user color selection.
-  - Accept the user answer in format: {name, hex, rgb}
-  - Set the user selected color in BGR (convert from RGB to BGR) to be the text color
-  - The user answer here will refer to the initial/default color of the text on the canopy.
     
-  Question # 4. **Logo Upload**:
+  Question # 3. **Logo Upload**:
     - Prompt the user to upload their logo:
     - {content}: ["Please upload your company logo to be displayed on the canopy."]
 
-  Question #5. **Generate Mockups Before Add-ons:**
+  Question #4. **Generate Mockups Before Add-ons:**
     - Once the primary color and logo are provided, EXPLICITLY CALL the generateCanopyMockups tool.
         - Set the companyName for the valences texts (front, back, left, right) as default/initial state for valences if valence texts are not already set and proceed
         - Set the user selected color for the valences (front, back, left, right) and peaks (front, back, left, right) as default/initial state for regions if colors are not already set and proceed
         - Tent type is no-walls here
-        - {content}: "Your mockups are being generated."
-        - {selectorName}: "Change mockups"
-            - {options}: [
-              { "name": "Change mockup design", "value": "design-changes", selected: false },
-              { "name": "Select add-ons", "value": "add-ons", selected: false }
-            ]
+          - {content}: "Your mockups are being generated."
+          - {selectorName}: "Change mockups"
+          - {options}: [
+            { "name": "Change mockup design", "value": "design-changes", selected: false },
+            { "name": "Select add-ons", "value": "add-ons", selected: false }
+          ]
       
       Step 2. As soon as user information and the mockupRequestId have been recieved, EXPLICTLY call the showGeneratedMockups tool with ALL of the following values (content, mockupRequestId, selectorName, options) to display the generated mockups:
             - {content}: "Thank you, here are your mockups!"
@@ -50,12 +42,13 @@ export const PROMPT_INSTRUCTIONS = `
             - {mockupRequestId}: The recieved mockupRequestId
             
         Step 3a. If the user selects "Change mockup design" EXPLICITLY call the renderButtons tool with the following values:
-            - {selectorName}: "Choose Design Changes"
+            - {content}: "What would you like to change?"
             - {isMultiSelect}: true
             - {options}: [
                 { "name": "Upload new logo", "value": "upload-logo", selected: false, edit: true },
                 { "name": "Separate colors for each print location", "value": "separate-colors", selected: [isAlreadySelected], edit: true },
-                { "name": "Separate texts for each valence", "value": "separate-texts", selected: [isAlreadySelected], edit: true }
+                { "name": "Separate texts for each valence", "value": "separate-texts", selected: [isAlreadySelected], edit: true },
+                { "name": "Change text color", "value": "text-color", selected: [isAlreadySelected], edit: true }
               ]
             - The renderButtons tool should ALWAYS be explicitly called every time the user selects "Change mockup design", even if the user has already selected "Change mockup designs" before.
             - A design change is selected if the selected property of that design change in the Design Changes options array is true.
@@ -94,6 +87,14 @@ export const PROMPT_INSTRUCTIONS = `
                     value {valencesTexts.right}
                   }]
                 - Change the respective field value as per the user input.
+              
+              4. If the user selects "Change text color":
+                - EXPLICITLY call the renderColorPicker tool with the following value:
+                  - {content}: "Please pick a color for the text on your canopy"
+                - Accept the user answer in format: {name, hex, rgb}
+                - Set the user selected color in BGR (convert from RGB to BGR) to be the text color
+                - The user answer here will refer to the color of the text on the canopy.
+
             - User can select multiple design changes. The order to process them should be exactly the same as listed above, regardless of the order in which they are selected.
             - When every selected design change is processed completely and the user has provided the required inputs for all the selected design changes, generate the mockups.
             - User can edit the design changes at any point in the process. If the user edits a design change, set the respective field value back to the the previous value and restart the process from Step 1 of Question 5 with all explicit tool Calls.
@@ -104,7 +105,7 @@ export const PROMPT_INSTRUCTIONS = `
             - Do not assume that the user wants to keep their previous selections. Always give them the opportunity to change or de-select options via renderButtons before generating mockups.
         
         Step 3b. If the user selects "Select add-ons" EXPLICITLY call the renderButtons tool with the following values:
-          - {selectorName}: "Select Add-Ons"
+          - {content}: "Please select add-ons"
           - {isMultiSelect}: true
           - {options}: [
               { "name": "10' Half Walls", "value": "half-walls", selected: false, edit: true },
@@ -143,7 +144,7 @@ export const PROMPT_INSTRUCTIONS = `
           - Do NOT assume that the user wants to keep their previous selections. Always give them the opportunity to change or de-select options via renderButtons before generating mockups.
 
           
-      Step 4. If the user selects "No," ask them which details they want to change, make the updates.
+      Step 4. If the user selects "No," ask them which details they want to change and then consequently make the updates.
 
       ** Place order Workflow:** (If the user clicks on "Place order" button)
         If the "Place Order" option is selected,
@@ -157,7 +158,6 @@ export const PROMPT_INSTRUCTIONS = `
     - Ask one question at a time.
     - All questions are marked as required.
     - Ensure questions are dynamic, concise, and never repeated unnecessarily.
-    - Never display summary except for the final confirmation step.
     - KEEP TRACK OF THE QUESTIONS ASKED WITH THE USER INPUTS AND ASK THE NEXT QUESTION BASED ON THE PREVIOUS INPUTS.
     - NEVER STOP IN BETWEEN THE QUESTIONS once the user response has been received.
     - Always show the name of the selected option rather than value in the questions if needed.
@@ -175,14 +175,14 @@ export const PROMPT_INSTRUCTIONS = `
   ** Tool Guidelines:**
     - EXPLICITLY CALL the appropriate tool function at EACH step where mentioned..
     - Whenever asking the user a closed ended question, EXPLICITLY CALL the renderButtons tool function. Below are the questions that are closed ended: 
-      - Question # 5: (Confirmation of the inputs provided by the user, region selection (IF ANY))
+      - Question # 4: (Confirmation of the inputs provided by the user, region selection (IF ANY))
     - Whenever asking the user to select a color, EXPLICITLY CALL the renderColorPicker tool function. Below are the questions that require color selection:
       - Question # 2: (Primary color selection)
-      - Question # 3: (Text color selection)
+      - For text color selection
     - Whenever asking the user to provide text for multiple fields, EXPLICITLY CALL the renderTextInputGroup tool function. Below are the questions that require text input:
-      - Question # 5: (If Separate text for each valence Text Add-on Selected)
+      - Question # 4: (If Separate text for each valence Text Add-on Selected)
     - Whenever asking the user to Separate color for each print location, EXPLICITLY CALL the renderRegionsColorsManager tool function. Below are the questions that require color selection:
-      - Question # 5: (If Separate color for each print location Add-on Selected)
+      - Question # 4: (If Separate color for each print location Add-on Selected)
     - **generateCanopyMockups tool function**
       - EXPLICITLY CALL the generateCanopyMockups tool function to generate the mockups of the canopy whenever the user confirms the inputs.
       - WHILE SENDING COLORS TO THE generateCanopyMockups TOOL FUNCTION, ALWAYS SEND THE BGR VALUES OF THE COLORS IN THE FOLLOWING FORMAT: \`[B, G, R]\`

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -147,11 +147,8 @@ export const PROMPT_INSTRUCTIONS = `
       Step 4. If the user selects "No," ask them which details they want to change and then consequently make the updates.
 
       ** Place order Workflow:** (If the user clicks on "Place order" button)
-        If the "Place Order" option is selected,
-          - If the user email and phone number both are provided, inform the user about the order placement by mentioning the email and phone number order is placed on.
-          - There will be no confirmation or notification to user.
-          - Otherwise, if the user email and phone number are not provided, MAKE SURE TO EXPLICITLY call the "placeFinalOrder" tool function with the following format:
-            - {content}: {assistantMessage asking user for details to place the order}
+        If the "Place Order" option is selected, EXPLICITLY CALL THE TOOL FUNCTION, placeFinalOrder with the below format.
+          - {content}: "Thank you for placing your order with us! If you have any questions or need further assistance, please feel free to contact us. Have a great day!"
         - DO NOT generate mockups at this step.
     
   ** Questions Guidelines:**

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -49,7 +49,7 @@ export const PROMPT_INSTRUCTIONS = `
         - Tent type is no-walls here
         - {content}: "Your mockups are being generated. In the meanwhile, please provide the following information."
       
-      Step 3. EXPLICTLY call the showGeneratedMockups tool with ALL of the following values (content, mockupRequestId, selectorName, options) to display the generated mockups:
+      Step 3. As soon as user information and the mockupRequestId have been recieved, EXPLICTLY call the showGeneratedMockups tool with ALL of the following values (content, mockupRequestId, selectorName, options) to display the generated mockups:
             - {content}: "Thank you, here are your mockups!"
             - {selectorName}: "Change mockups"
             - {options}: [

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -95,7 +95,6 @@ export const PROMPT_INSTRUCTIONS = `
             - The user can de-select any design changes at any point in the process. If the user de-selects a design change, set the respective field value/values back to the INITIAL state and remove the design change from the summary and restart the process from Step 1 of Question 5 with all explicit tool Calls.
             - Set the respective field value back to the default/INITIAL state if the user de-selects a design change.
             - EXPLICITLY CALL THE TOOL FUNCTIONS WHERE MENTIONED IN EVERY ITERATION OF THE PROCESS.
-            - This flow is to be repeated EVERY TIME the user selects "Change mockup design". ALWAYS call the renderButtons tool with the given options before generating mockups.
             - IMPORTANT: EVEN IF the user has already selected all available design changes before, and EVEN IF the selected property for every design change is true, you MUST ALWAYS explicitly call the renderButtons tool with the design change options EVERY TIME the user selects ‘Change mockup design’. NEVER skip this step regardless of previous selections.
             - Do not assume that the user wants to keep their previous selections. Always give them the opportunity to change or de-select options via renderButtons before generating mockups.
         
@@ -135,7 +134,6 @@ export const PROMPT_INSTRUCTIONS = `
           - The user can de-select any add-ons at any point in the process. If the user de-selects an add-on, set the respective field value/values back to the default/INITIAL state and remove the add-on from the summary and restart the process from Step 1 of Question 5 with all explicit tool Calls.
           - Set the respective field value back to the default/INITIAL state if the user de-selects an add-on.
           - EXPLICITLY CALL THE TOOL FUNCTIONS WHERE MENTION IN EVERY ITERATION OF THE PROCESS.
-          - This flow is to be repeated EVERY TIME the user selects "Select add-ons". ALWAYS call the renderButtons tool with the given options before generating mockups.
           - IMPORTANT: EVEN IF the user has already selected all available add-ons before, and EVEN IF the selected property for every add-on is true, you MUST ALWAYS explicitly call the renderButtons tool with the design change options EVERY TIME the user selects ‘Select add-ons’. NEVER skip this step regardless of previous selections.
           - Do NOT assume that the user wants to keep their previous selections. Always give them the opportunity to change or de-select options via renderButtons before generating mockups.
 

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -33,7 +33,12 @@ export const PROMPT_INSTRUCTIONS = `
         - Set the companyName for the valences texts (front, back, left, right) as default/initial state for valences if valence texts are not already set and proceed
         - Set the user selected color for the valences (front, back, left, right) and peaks (front, back, left, right) as default/initial state for regions if colors are not already set and proceed
         - Tent type is no-walls here
-        - {content}: "Your mockups are being generated. In the meanwhile, please provide the following information."
+        - {content}: "Your mockups are being generated."
+        - {selectorName}: "Change mockups"
+            - {options}: [
+              { "name": "Change mockup design", "value": "design-changes", selected: false },
+              { "name": "Select add-ons", "value": "add-ons", selected: false }
+            ]
       
       Step 2. As soon as user information and the mockupRequestId have been recieved, EXPLICTLY call the showGeneratedMockups tool with ALL of the following values (content, mockupRequestId, selectorName, options) to display the generated mockups:
             - {content}: "Thank you, here are your mockups!"
@@ -143,6 +148,7 @@ export const PROMPT_INSTRUCTIONS = `
       ** Place order Workflow:** (If the user clicks on "Place order" button)
         If the "Place Order" option is selected,
           - If the user email and phone number both are provided, inform the user about the order placement by mentioning the email and phone number order is placed on.
+          - There will be no confirmation or notification to user.
           - Otherwise, if the user email and phone number are not provided, MAKE SURE TO EXPLICITLY call the "placeFinalOrder" tool function with the following format:
             - {content}: {assistantMessage asking user for details to place the order}
         - DO NOT generate mockups at this step.

--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -43,18 +43,22 @@ export const PROMPT_INSTRUCTIONS = `
              { "name": "Yes, generate mockups", "value": "generate-mockups", selected: [isAlreadySelected] },
              { "name": "No, I need to make changes", "value": "no, edit", selected: [isAlreadySelected] }
            ]
-      Step 2. If the user selects "Yes, generate mockups," EXPLICITLY CALL the generateCanopyMockups tool and display the mockups to the user.
+      Step 2. If the user selects "Yes, generate mockups," EXPLICITLY CALL the generateCanopyMockups tool.
         - Set the companyName for the valences texts (front, back, left, right) as default/initial state for valences if valence texts are not already set and proceed
         - Set the user selected color for the valences (front, back, left, right) and peaks (front, back, left, right) as default/initial state for regions if colors are not already set and proceed
         - Tent type is no-walls here
-        - Once the mockups have been generated, confirm what the user would like to do next 
-          - {selectorName}: "Change mockups"
-          - {options}: [
-            { "name": "Change mockup design", "value": "design-changes", selected: false },
-            { "name": "Select add-ons", "value": "add-ons", selected: false }
-          ]
+        - {content}: "Your mockups are being generated. In the meanwhile, please provide the following information."
+      
+      Step 3. EXPLICTLY call the showGeneratedMockups tool with ALL of the following values (content, mockupRequestId, selectorName, options) to display the generated mockups:
+            - {content}: "Thank you, here are your mockups!"
+            - {selectorName}: "Change mockups"
+            - {options}: [
+              { "name": "Change mockup design", "value": "design-changes", selected: false },
+              { "name": "Select add-ons", "value": "add-ons", selected: false }
+            ]
+            - {mockupRequestId}: The recieved mockupRequestId
             
-        Step 2a. If the user selects "Change mockup design" EXPLICITLY call the renderButtons tool with the following values:
+        Step 3a. If the user selects "Change mockup design" EXPLICITLY call the renderButtons tool with the following values:
             - {selectorName}: "Choose Design Changes"
             - {isMultiSelect}: true
             - {options}: [
@@ -109,7 +113,7 @@ export const PROMPT_INSTRUCTIONS = `
             - IMPORTANT: EVEN IF the user has already selected all available design changes before, and EVEN IF the selected property for every design change is true, you MUST ALWAYS explicitly call the renderButtons tool with the design change options EVERY TIME the user selects ‘Change mockup design’. NEVER skip this step regardless of previous selections.
             - Do not assume that the user wants to keep their previous selections. Always give them the opportunity to change or de-select options via renderButtons before generating mockups.
         
-        Step 2b. If the user selects "Select add-ons" EXPLICITLY call the renderButtons tool with the following values:
+        Step 3b. If the user selects "Select add-ons" EXPLICITLY call the renderButtons tool with the following values:
           - {selectorName}: "Select Add-Ons"
           - {isMultiSelect}: true
           - {options}: [
@@ -150,7 +154,7 @@ export const PROMPT_INSTRUCTIONS = `
           - Do NOT assume that the user wants to keep their previous selections. Always give them the opportunity to change or de-select options via renderButtons before generating mockups.
 
           
-      Step 3. If the user selects "No," ask them which details they want to change, make the updates.
+      Step 4. If the user selects "No," ask them which details they want to change, make the updates.
 
       ** Place order Workflow:** (If the user clicks on "Place order" button)
         If the "Place Order" option is selected,
@@ -211,7 +215,7 @@ export const TOOL_FUNCTIONS = {
   RENDER_REGION_MANAGER: 'renderRegionManager',
   GENERATE_CANOPY_MOCKUPS: 'generateCanopyMockups',
   PLACE_FINAL_ORDER: 'placeFinalOrder',
-  SHOW_USER_DETAILS: 'showUserDetails'
+  SHOW_GENERATED_MOCKUPS: 'showGeneratedMockups'
 }
 
 export const INITIAL_CHAT_MESSAGE =

--- a/lib/ai-tools/schemas.ts
+++ b/lib/ai-tools/schemas.ts
@@ -159,7 +159,27 @@ export const CustomCanopyToolSchema = z.object({
         .describe('Color of the table to be displayed on the tent banner')
     })
     .describe('Details of the tent to be generated')
-    .required()
+    .required(),
+  selectorName: z
+    .string()
+    .describe('The name of the selector for the mockup changes'),
+  options: z
+    .array(
+      z.object({
+        name: z.string().describe('The name for the button'),
+        value: z.string().describe('The value for the button'),
+        selected: z
+          .boolean()
+          .describe('Whether the button is selected')
+          .default(false),
+        edit: z
+          .boolean()
+          .describe('The edit state for the button')
+          .default(false)
+      })
+    )
+    .describe('The options to display')
+    .nonempty()
 })
 
 export const ShowGeneratedMockupsToolSchema = z.object({

--- a/lib/ai-tools/schemas.ts
+++ b/lib/ai-tools/schemas.ts
@@ -85,31 +85,10 @@ export const RegionsColorsManagerSchema = z.object({
 
 export const CustomCanopyToolSchema = z.object({
   content: z
-    .array(z.string())
+    .string()
     .describe(
       'The content to be displayed for the canopy tool while waiting, after the image and while displaying add-ons options.'
-    )
-    .length(3),
-  selectorName: z
-    .string()
-    .describe('The name of the selector for the mockup changes'),
-  options: z
-    .array(
-      z.object({
-        name: z.string().describe('The name for the button'),
-        value: z.string().describe('The value for the button'),
-        selected: z
-          .boolean()
-          .describe('Whether the button is selected')
-          .default(false),
-        edit: z
-          .boolean()
-          .describe('The edit state for the button')
-          .default(false)
-      })
-    )
-    .describe('The options to display')
-    .nonempty(),
+    ),
   payload: z
     .object({
       companyName: z.string().describe('Name of the company or organization'),
@@ -181,6 +160,37 @@ export const CustomCanopyToolSchema = z.object({
     })
     .describe('Details of the tent to be generated')
     .required()
+})
+
+export const ShowGeneratedMockupsToolSchema = z.object({
+  content: z
+    .string()
+    .describe(
+      'The content to be displayed for the canopy tool when showing the mockup images.'
+    ),
+  mockupRequestId: z
+    .string()
+    .describe('The ID for the mockup generation request'),
+  selectorName: z
+    .string()
+    .describe('The name of the selector for the mockup changes'),
+  options: z
+    .array(
+      z.object({
+        name: z.string().describe('The name for the button'),
+        value: z.string().describe('The value for the button'),
+        selected: z
+          .boolean()
+          .describe('Whether the button is selected')
+          .default(false),
+        edit: z
+          .boolean()
+          .describe('The edit state for the button')
+          .default(false)
+      })
+    )
+    .describe('The options to display')
+    .nonempty()
 })
 
 export const PlaceFinalOrderSchema = z.object({

--- a/lib/ai-tools/tool-functions.tsx
+++ b/lib/ai-tools/tool-functions.tsx
@@ -227,7 +227,7 @@ export function generateCanopyMockups(history: any, messageId: string) {
         <BotMessage content={content}>
           <UserDetailsForm
             messageId={messageId}
-            inputFields={inputFields}
+            userFields={inputFields}
             mockupRequestId={mockupRequestId}
           />
         </BotMessage>

--- a/lib/ai-tools/tool-functions.tsx
+++ b/lib/ai-tools/tool-functions.tsx
@@ -20,7 +20,7 @@ import {
   generateTentMockupsApi,
   pollMockupGeneration
 } from '../redux/apis/tent-mockup-prompt'
-import { MockupResponse, Roles, TentMockUpPrompt } from '../types'
+import { MockupResponse, Roles, Session, TentMockUpPrompt } from '../types'
 import { TOOL_FUNCTIONS } from './constants'
 import { modifyAIState } from './utils'
 import { ChatTextInputGroup } from '@/components/chat-text-input-group'
@@ -28,6 +28,7 @@ import ChatActionMultiSelector from '@/components/chat-action-multi-selector'
 import RegionsColorsManager from '@/components/regions_colors_manager'
 import { ColorLabelPickerSet } from '@/components/color-label-picker-set'
 import { UserDetailsForm } from '@/components/user-details-form'
+import { auth } from '@/auth'
 
 function modifyToolAIState(history: any, content: ToolContent) {
   modifyAIState(history, {
@@ -195,6 +196,21 @@ export function generateCanopyMockups(history: any, messageId: string) {
         ...(payload as TentMockUpPrompt),
         id: history.get().id
       })
+      const session = (await auth()) as Session
+      const inputFields = [
+        {
+          label: 'Email',
+          value: session?.user?.email || '',
+          disabled: !!session?.user?.email,
+          type: 'email'
+        },
+        {
+          label: 'Phone Number',
+          value: session?.user?.phoneNumber ?? '',
+          type: 'tel',
+          disabled: !!session?.user?.phoneNumber
+        }
+      ]
 
       modifyToolAIState(history, [
         {
@@ -211,6 +227,7 @@ export function generateCanopyMockups(history: any, messageId: string) {
         <BotMessage content={content}>
           <UserDetailsForm
             messageId={messageId}
+            inputFields={inputFields}
             mockupRequestId={mockupRequestId}
           />
         </BotMessage>

--- a/lib/ai-tools/tool-functions.tsx
+++ b/lib/ai-tools/tool-functions.tsx
@@ -187,7 +187,7 @@ export function generateCanopyMockups(history: any, messageId: string) {
     description:
       'Starts backend mockup generation and shows user form while waiting',
     parameters: CustomCanopyToolSchema,
-    generate: async function* ({
+    generate: async function ({
       content,
       payload
     }: z.infer<typeof CustomCanopyToolSchema>) {
@@ -223,14 +223,12 @@ export function showGeneratedMockups(history: any, messageId: string) {
   return {
     description: 'Displays mockups after user details are submitted',
     parameters: ShowGeneratedMockupsToolSchema,
-    generate: async function* ({
+    generate: async function ({
       content,
       mockupRequestId,
       options,
       selectorName
     }: z.infer<typeof ShowGeneratedMockupsToolSchema>) {
-      yield <BotCard>{content}</BotCard>
-      debugger
       const chatID = history.get().id
       const outputDir = `chat:${chatID}`
       const mockups: MockupResponse = await pollMockupGeneration(
@@ -244,14 +242,19 @@ export function showGeneratedMockups(history: any, messageId: string) {
           toolName: TOOL_FUNCTIONS.SHOW_GENERATED_MOCKUPS,
           result: {
             message: content,
-            props: { mockupRequestId, options, selectorName, mockups }
+            props: {
+              options,
+              selectorName,
+              mockups,
+              action: 'Place Order'
+            }
           }
         }
       ] as ToolContent)
 
       return (
-        <BotMessage content="Here are your mockups!">
-          <Carousal mockups={mockups} open />
+        <BotMessage content={content}>
+          <Carousal mockups={mockups} open={true} />
           <ChatActionMultiSelector
             action="Place Order"
             selectorName={selectorName}

--- a/lib/ai-tools/tool-functions.tsx
+++ b/lib/ai-tools/tool-functions.tsx
@@ -205,7 +205,7 @@ export function generateCanopyMockups(history: any, messageId: string) {
           type: 'email'
         },
         {
-          label: 'Phone Number',
+          label: 'Phone No.',
           value: session?.user?.phoneNumber ?? '',
           type: 'tel',
           disabled: !!session?.user?.phoneNumber

--- a/lib/ai-tools/tool-functions.tsx
+++ b/lib/ai-tools/tool-functions.tsx
@@ -274,12 +274,14 @@ export function generateCanopyMockups(history: any, messageId: string) {
         {
           label: 'Email',
           value: '',
-          type: 'email'
+          type: 'email',
+          placeholder: 'example@gmail.com'
         },
         {
           label: 'Phone No.',
           value: '',
-          type: 'tel'
+          type: 'tel',
+          placeholder: '+1 (555) 555-1234'
         }
       ]
 

--- a/lib/ai-tools/utils.tsx
+++ b/lib/ai-tools/utils.tsx
@@ -88,16 +88,13 @@ const getToolMessage = (content: ToolContent): ClientMessage => {
         return <RegionsColorsManager messageId={toolCallId} {...props} />
 
       case TOOL_FUNCTIONS.GENERATE_CANOPY_MOCKUPS:
+        return <UserDetailsForm {...props} messageId={toolCallId} />
+
+      case TOOL_FUNCTIONS.SHOW_GENERATED_MOCKUPS:
         return (
           <>
             <Carousal {...props} />
             <ChatActionMultiSelector {...props} messageId={toolCallId} />
-          </>
-        )
-      case TOOL_FUNCTIONS.PLACE_FINAL_ORDER:
-        return (
-          <>
-            <UserDetailsForm {...props} messageId={toolCallId} />
           </>
         )
 

--- a/lib/redux/apis/tent-mockup-prompt.ts
+++ b/lib/redux/apis/tent-mockup-prompt.ts
@@ -1,5 +1,5 @@
 import { TENT_MOCKUP_VALIDATIONS } from '@/app/constants'
-import { TentMockUpPrompt, MockupResponse } from '@/lib/types'
+import { TentMockUpPrompt, MockupResponse, MockupIdResponse } from '@/lib/types'
 import { createFormData } from '@/lib/utils/tent-mockup'
 import { ImagePart } from 'ai'
 
@@ -9,7 +9,7 @@ const fetchLogoFile = async (logo: ImagePart): Promise<File> => {
   return new File([blob], logo.type, { type: logo.mimeType })
 }
 
-const fetchMockups = async (formData: FormData): Promise<MockupResponse> => {
+const fetchMockups = async (formData: FormData): Promise<MockupIdResponse> => {
   const response = await fetch(
     `${process.env.NEXT_PUBLIC_CUSTOM_CANOPY_SERVER_URL}/create-mockups`,
     {
@@ -25,7 +25,7 @@ const fetchMockups = async (formData: FormData): Promise<MockupResponse> => {
   }
 
   const mockups = await response.json()
-  return mockups as MockupResponse
+  return mockups as MockupIdResponse
 }
 
 export const generateTentMockupsApi = async (
@@ -40,5 +40,37 @@ export const generateTentMockupsApi = async (
     return await fetchMockups(formData)
   } catch (error) {
     throw new Error((error as Error).message || 'Something went wrong!')
+  }
+}
+
+export async function pollMockupGeneration(
+  mockupRequestId: string,
+  outputDir: string,
+  delay = 2000,
+  retries = 10
+) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_CUSTOM_CANOPY_SERVER_URL}/mockup-status?request_id=${mockupRequestId}&output_dir=${outputDir}`
+      )
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch mockup status')
+      }
+
+      const data = await response.json()
+      if (data.status === 'ready') {
+        return data.mockups
+      }
+
+      if (data.status === 'error') {
+        throw new Error(data.error || 'Mockup generation failed')
+      }
+    } catch (error) {
+      console.error('Polling error:', error)
+    }
+
+    await new Promise(resolve => setTimeout(resolve, delay))
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -36,6 +36,7 @@ export interface Session {
   user: {
     id: string
     email: string
+    phoneNumber?: string
   }
 }
 
@@ -47,7 +48,7 @@ export interface AuthResult {
 export interface User extends Record<string, any> {
   id: string
   email: string
-  password: string
+  phoneNumber: string
   salt: string
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -126,6 +126,10 @@ export type MockupResponse = {
   'no-walls': PutBlobResult
 }
 
+export type MockupIdResponse = {
+  mockupRequestId: string
+}
+
 export type ActionResult = {
   type: string
   resultCode: ResultCode

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "framer-motion": "^11.3.30",
     "geist": "^1.3.1",
     "jszip": "^3.10.1",
+    "lodash": "^4.17.21",
     "lz-string": "^1.5.0",
     "nanoid": "^5.0.7",
     "next": "14.2.6",
@@ -58,6 +59,7 @@
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.14",
+    "@types/lodash": "^4.17.16",
     "@types/node": "^22.5.0",
     "@types/react": "^18.3.4",
     "@types/react-dom": "^18.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -810,6 +810,11 @@
   resolved "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz"
   integrity sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==
 
+"@types/lodash@^4.17.16":
+  version "4.17.16"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.16.tgz#94ae78fab4a38d73086e962d0b65c30d816bfb0a"
+  integrity sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==
+
 "@types/mdast@^3.0.0":
   version "3.0.15"
   resolved "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz"
@@ -1895,6 +1900,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 longest-streak@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
## Description

This PR corresponds to the following tasks:
- [Take user details only once](https://www.notion.so/conradlabshq/Take-user-details-only-once-1d9512441d3c80f4b694db3132c10edc?pvs=4)
- [Reorder guidance tab images](https://www.notion.so/conradlabshq/UI-Enhancements-1d9512441d3c809ea6afdda7f3d60713?pvs=4)
- [Improve user details form placeholders and formatting](https://www.notion.so/conradlabshq/UI-Enhancements-1d9512441d3c809ea6afdda7f3d60713?pvs=4)
- [Move customizable text to design changes](https://www.notion.so/conradlabshq/Move-customizable-text-color-to-be-a-design-change-1d9512441d3c8051b0f7d11f6b6a45aa?pvs=4)

A user is now only prompted for their details if they are not logged in. As soon as an anonymous users provide their information, they are logged in. 
Guidance tab images have also been reordered and the form placeholders and formatting has been approved.
Text colour can only be specified as a design change and not a part of the basic flow