### PR TITLE
Feat: Contact design specialist to place final order

### DIFF
--- a/lib/ai-tools/constants.ts
+++ b/lib/ai-tools/constants.ts
@@ -149,10 +149,10 @@ export const PROMPT_INSTRUCTIONS = `
           - Do NOT assume that the user wants to keep their previous selections. Always give them the opportunity to change or de-select options via renderButtons before generating mockups.
           - NEVER EVER AUTO GENERATE THE MOCKUPS IF THE USER HAS ALREADY SELECTED ALL ADD-ONS AND HE/SHE SELECTS Select add-ons OPTION AGAIN NO MATTER HOW MANY TIMES IT IS SELECTED.
 
-      ** Place order Workflow:** (If the user clicks on "Place order" button)
-        If the "Place Order" option is selected, EXPLICITLY CALL THE TOOL FUNCTION, placeFinalOrder with the below format.
-          - {content}: "Thank you for placing your order with us! If you have any questions or need further assistance, please feel free to contact us. Have a great day!"
-        - DO NOT generate mockups at this step.
+      ** Have a Design Specialist Contact Me Workflow:** (If the user clicks on "Have a Design Specialist Contact Me" button)
+        If the "Have a Design Specialist Contact Me" option is selected, EXPLICITLY CALL THE placeFinalOrder tool with the following parameters (DO NOT generate mockups at this step):
+          - {content}: "Thank you, a design specialist has been notified and will contact you shortly. If you have any questions or need further assistance, please feel free to contact us. Have a great day!"
+        - DO NOT under any circumstances generate mockups at this step.
     
   ** Questions Guidelines:**
     - Ask one question at a time.

--- a/lib/redux/apis/tent-mockup-prompt.ts
+++ b/lib/redux/apis/tent-mockup-prompt.ts
@@ -63,6 +63,6 @@ export const placeOrder = async (order_id: string, email: string, mockups: Mocku
 
   if (!response.ok) {
     console.error('Response from the backend is: ', response)
-    throw new Error('Failed to place order')
+    throw new Error(`Failed to place order: ${response.status} ${response.statusText}`)
   }
 }

--- a/lib/redux/apis/tent-mockup-prompt.ts
+++ b/lib/redux/apis/tent-mockup-prompt.ts
@@ -43,3 +43,26 @@ export const generateTentMockupsApi = async (
     throw new Error((error as Error).message || 'Something went wrong!')
   }
 }
+
+export const placeOrder = async (order_id: string, email: string, mockups: MockupResponse, canopy_payload: TentMockUpPrompt, phoneNumber?: string) => {
+  const formRequestBody = new FormData()
+  formRequestBody.append("order_id", order_id)
+  formRequestBody.append("user_email", email)
+  formRequestBody.append("user_phone", phoneNumber || '')
+  formRequestBody.append("mockups", JSON.stringify(mockups))
+  formRequestBody.append("canopy_requirements", JSON.stringify(canopy_payload))
+
+
+  const response = await fetch(`${process.env.NEXT_PUBLIC_CUSTOM_CANOPY_SERVER_URL}/place-order`, {
+    method: 'POST',
+    body: formRequestBody,
+    headers: {
+      Connection: 'keep-alive'
+    }
+  })
+
+  if (!response.ok) {
+    console.error('Response from the backend is: ', response)
+    throw new Error('Failed to place order')
+  }
+}


### PR DESCRIPTION
## Description

This PR corresponds to the following [task](https://www.notion.so/conradlabshq/Add-support-to-send-order-information-to-design-specialist-1df512441d3c80b1b00bd832cc3f3fae?pvs=4)

Added support to send user order details to a Custom Canopy design specialist when the user requests to do so.
